### PR TITLE
Feat/Implementando lista de tarefas e inicia tradução I18n

### DIFF
--- a/app/controllers/event_tasks_controller.rb
+++ b/app/controllers/event_tasks_controller.rb
@@ -2,7 +2,9 @@ class EventTasksController < ApplicationController
   before_action :authenticate_user!
   before_action :check_event_content_owner, only: :create
 
-  def index; end
+  def index
+    @event_tasks = current_user.event_tasks
+  end
 
   def new
     @event_task = current_user.event_tasks.build

--- a/app/controllers/event_tasks_controller.rb
+++ b/app/controllers/event_tasks_controller.rb
@@ -27,6 +27,7 @@ class EventTasksController < ApplicationController
   end
 
   def check_event_content_owner
+    return unless current_user.event_contents.present?
     contents = params[:event_task][:event_content_ids].reject(&:blank?)
     contents.each do |content|
       unless current_user.event_contents.find_by(id: content)

--- a/app/views/event_tasks/_event_task.html.erb
+++ b/app/views/event_tasks/_event_task.html.erb
@@ -1,0 +1,6 @@
+<%= link_to(event_task, class: "card") do %>
+    <div >
+      <p class="card_title_2">Tarefa</p>
+      <h3 class="card_title"><%= event_task.name %></h3>
+    </div>
+  <% end %>

--- a/app/views/event_tasks/_event_task.html.erb
+++ b/app/views/event_tasks/_event_task.html.erb
@@ -1,6 +1,6 @@
 <%= link_to(event_task, class: "card") do %>
-    <div >
-      <p class="card_title_2">Tarefa</p>
-      <h3 class="card_title"><%= event_task.name %></h3>
-    </div>
-  <% end %>
+  <div >
+    <p class="card_title_2"><%= t('.task') %></p>
+    <h3 class="card_title"><%= event_task.name %></h3>
+  </div>
+<% end %>

--- a/app/views/event_tasks/index.html.erb
+++ b/app/views/event_tasks/index.html.erb
@@ -1,10 +1,14 @@
-<h2 class="heading-2">Minhas Tarefas</h2>
+<h2 class="heading-2"><%= t('.my_tasks') %></h2>
 
-<%= link_to 'Cadastrar Tarefa', new_event_task_path, data: { turbo: false }, class: 'link-primary' %>
+<%= link_to t('.new_task'), new_event_task_path, data: { turbo: false }, class: 'link-primary' %>
 <div>
   <% if @event_tasks.any? %>
     <div class="card_container">
       <%= render @event_tasks %>
+    </div>
+  <% else %>
+    <div>
+      <%= t('.no_tasks')%>
     </div>
   <% end %>
 </div>

--- a/app/views/event_tasks/index.html.erb
+++ b/app/views/event_tasks/index.html.erb
@@ -1,1 +1,10 @@
-<%= link_to 'Cadastrar Tarefa', new_event_task_path, data: { turbo: false }%>
+<h2 class="heading-2">Minhas Tarefas</h2>
+
+<%= link_to 'Cadastrar Tarefa', new_event_task_path, data: { turbo: false }, class: 'link-primary' %>
+<div>
+  <% if @event_tasks.any? %>
+    <div class="card_container">
+      <%= render @event_tasks %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/event_tasks/new.html.erb
+++ b/app/views/event_tasks/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class='heading-2'>Cadastrar tarefa</h2>
+<h2 class='heading-2'> <%= t('.title') %></h2>
 
 <%= form_with model: @event_task, data: { turbo: false } do |f| %>
   <div>
@@ -28,9 +28,9 @@
     <% end %>
   </div>
   <div class="col-span-2">
-        <%= f.label :event_content_ids, 'Conteudos', class: "block text-sm font-medium text-gray-700" %>
+        <%= f.label :event_content_ids, class: "block text-sm font-medium text-gray-700" %>
           <% if @contents.blank? %>
-            <p>Nenhum conteúdo cadastrado.</p>
+            <p> <%= t('.no_contents') %></p>
           <% else %>
             <%= f.collection_check_boxes(:event_content_ids, @contents, :id, :title) do |b| %>
                 <%= b.check_box %>
@@ -39,7 +39,7 @@
           <% end %>
       </div>
   <div>
-    <%= f.submit 'Salvar', class: 'btn-primary'%>
+    <%= f.submit t('.save'), class: 'btn-primary'%>
   </div>
 <% end %>
 

--- a/config/locales/model/event_task.pt-BR.yml
+++ b/config/locales/model/event_task.pt-BR.yml
@@ -7,6 +7,7 @@ pt-BR:
         name: 'Título'
         description: 'Descrição'
         content: 'Conteúdos'
+        event_content_ids: 'Conteúdos'
         certificate_requirement: 'Obrigatória para emissão de certificado'
         certificate_requirements: 
           mandatory: 'Obrigatória'

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -1,0 +1,12 @@
+pt-BR:
+  event_tasks:
+    new:
+      title: 'Cadastrar Tarefa'
+      no_contents: 'Nenhum conteúdo cadastrado'
+      save: 'Salvar'
+    index:
+      my_tasks: 'Minhas Tarefas'
+      new_task: 'Cadastrar Tarefa'
+      no_tasks: 'Não há tarefas cadastradas!'
+    event_task:
+      task: 'Tarefa'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
   resources :event_contents, only: %i[ index show new create edit update ]
-  resources :event_tasks, only: %i[ index new create]
+  resources :event_tasks, only: %i[ index show new create ]
 end

--- a/spec/system/event_task/user_register_task_spec.rb
+++ b/spec/system/event_task/user_register_task_spec.rb
@@ -22,6 +22,22 @@ describe 'User register tasks' do
     check 'My content'
     click_on 'Salvar'
 
+    expect(page).to have_content('Tarefa cadastrada com sucesso!')
+    expect(EventTask.count).to eq 1
+    expect(current_path).to eq event_tasks_path
+  end
+
+  it 'with success without content' do
+    user = create(:user)
+
+    login_as user
+    visit new_event_task_path
+
+    fill_in 'Título', with: 'Tarefa 01'
+    fill_in 'Descrição', with: 'Lorem ipsum'
+    choose 'Obrigatória'
+    click_on 'Salvar'
+
     expect(EventTask.count).to eq 1
     expect(page).to have_content('Tarefa cadastrada com sucesso!')
     expect(current_path).to eq event_tasks_path

--- a/spec/system/event_task/user_view_task_list_spec.rb
+++ b/spec/system/event_task/user_view_task_list_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe 'user view task list', type: :system do
+  it 'and must be authenticated' do
+    user = create(:user, first_name: 'João')
+    create(:event_task, name: 'Tarefas iniciais básicas rails', user: user)
+    create(:event_task, name: 'Revisão rails 8.0', user: user)
+
+    visit event_tasks_path
+
+    expect(current_path).to eq new_user_session_path
+  end
+
+  it 'with success' do
+    user = create(:user, first_name: 'João')
+    create(:event_task, name: 'Tarefas iniciais básicas rails', user: user)
+    create(:event_task, name: 'Revisão rails 8.0', user: user)
+
+    login_as user
+    visit root_path
+    click_on 'Tarefas'
+
+    expect(page).to have_link 'Tarefas iniciais básicas rails'
+    expect(page).to have_link 'Revisão rails 8.0'
+    expect(current_path).to eq event_tasks_path
+  end
+
+  it 'and view only their tasks' do
+    first_user = create(:user, first_name: 'João')
+    create(:event_task, name: 'Revisão rails 8.0', user: first_user)
+    second_user = create(:user, first_name: 'Roberto')
+    create(:event_task, name: 'Tarefas iniciais básicas rails', user: second_user)
+
+    login_as second_user
+    visit event_tasks_path
+
+    expect(page).not_to have_link 'Revisão rails 8.0'
+    expect(page).to have_link 'Tarefas iniciais básicas rails'
+  end
+end

--- a/spec/system/event_task/user_view_task_list_spec.rb
+++ b/spec/system/event_task/user_view_task_list_spec.rb
@@ -37,4 +37,15 @@ describe 'user view task list', type: :system do
     expect(page).not_to have_link 'Revisão rails 8.0'
     expect(page).to have_link 'Tarefas iniciais básicas rails'
   end
+
+  it 'and dont have task previusly registered' do
+    user = create(:user, first_name: 'João')
+
+    login_as user
+    visit root_path
+    click_on 'Tarefas'
+
+    expect(page).to have_content 'Não há tarefas cadastradas!'
+    expect(current_path).to eq event_tasks_path
+  end
 end


### PR DESCRIPTION
Usuário vê lista de tarefas previamente cadastradas:
![tasks-list](https://github.com/user-attachments/assets/13922f99-8711-492f-961a-e4d2a701d425)

Aviso se não houver tarefa previamente cadastrada:
![no-task-message](https://github.com/user-attachments/assets/01b05f77-147d-4cb3-b310-81b9c1a1493d)

I18n implementado as novas telas:
![i18n_tasks](https://github.com/user-attachments/assets/97aa4953-f2a6-40a8-93b8-882db8947512)

Resolve #34 