### PR TITLE
feat: Adiciona visualização dos detalhes da tarefa e permir ver os conteúdos vinculados

### DIFF
--- a/app/controllers/event_tasks_controller.rb
+++ b/app/controllers/event_tasks_controller.rb
@@ -1,6 +1,7 @@
 class EventTasksController < ApplicationController
   before_action :authenticate_user!
   before_action :check_event_content_owner, only: :create
+  before_action :set_event_task, only: %i[ show edit ]
 
   def index
     @event_tasks = current_user.event_tasks
@@ -11,6 +12,13 @@ class EventTasksController < ApplicationController
     @contents = current_user.event_contents
   end
 
+  def show; end
+
+  def edit
+  end
+
+  def update
+  end
   def create
     @event_task = current_user.event_tasks.build(event_task_params)
     @contents = current_user.event_contents
@@ -25,6 +33,15 @@ class EventTasksController < ApplicationController
   def event_task_params
     params.require(:event_task).permit(:name, :description, :certificate_requirement, event_content_ids: [])
   end
+
+  def set_event_task
+    begin
+      @event_task = current_user.event_tasks.find(params[:id])
+    rescue
+      redirect_to events_path, notice: "Acesso não autorizado."
+    end
+  end
+
 
   def check_event_content_owner
     return unless current_user.event_contents.present?

--- a/app/views/event_tasks/show.html.erb
+++ b/app/views/event_tasks/show.html.erb
@@ -1,0 +1,40 @@
+<div class="flex">
+  <h2 class="heading-2"><%= @event_task.name %></h2>
+  <div class="ml-5 pt-2">
+    <%= link_to edit_event_task_path(@event_task), data: { turbo: false }, title: 'Editar' do %>
+      <%= image_tag 'pencil_edit.png', id: 'pencil_edit', class: 'icon' %>
+    <% end %>
+  </div>
+</div>
+
+<div class="mb-3">
+  <%= @event_task.description %>
+</div>
+
+<span>
+  <%= t('.task')%>
+  <%= t('.mandatory') if @event_task.mandatory? %> 
+  <%= t('.optional') if @event_task.optional? %> 
+</span>
+
+<div class="mt-5">
+  <% if @event_task.event_contents.any? %>
+    <div>
+      <strong><%= t('.attatched_contents') %></strong>
+      <div class="card_container">
+        <% @event_task.event_contents.each do |content| %>
+          <%= link_to(content, class: "card") do %>
+            <div >
+              <p class="card_title_2"><%= t('.content') %></p>
+              <h3 class="card_title"><%= content.title %></h3>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <div>
+      <strong> <%= t('.no_content_attetched')%> </strong>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -10,3 +10,10 @@ pt-BR:
       no_tasks: 'Não há tarefas cadastradas!'
     event_task:
       task: 'Tarefa'
+    show:
+      task: 'Tarefa'
+      mandatory: Obrigatória
+      optional: Opcional
+      no_content_attetched: 'Nenhum conteúdo vinculado.'
+      attatched_contents: 'Conteúdos vinculados:'
+      content: 'Conteúdo'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
   root "home#index"
   resources :events, only: %i[ index show ]
   resources :event_contents, only: %i[ index show new create edit update ]
-  resources :event_tasks, only: %i[ index show new create ]
+  resources :event_tasks, only: %i[ index show new create edit update ]
 end

--- a/spec/system/event_task/user_view_task_details_spec.rb
+++ b/spec/system/event_task/user_view_task_details_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'User view task details', type: :system do
+  it 'with sucess' do
+    user = create(:user, first_name: 'João')
+    content = user.event_contents.create!(title: 'Conteúdo de ruby')
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    EventTaskContent.create!(event_content: content, event_task: task)
+
+    login_as user
+    visit root_path
+    click_on 'Tarefas'
+    click_on 'Tarefa inicial'
+
+    expect(current_path).to eq event_task_path(task)
+    expect(page).to have_content 'Tarefa inicial'
+    expect(page).to have_content 'Desafio para iniciantes'
+    expect(page).to have_content 'Tarefa Opcional'
+    expect(page).to have_content 'Conteúdos vinculados'
+    expect(page).to have_link 'Conteúdo de ruby'
+  end
+
+  it 'and user is not authenticated' do
+    user = create(:user, first_name: 'João')
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+
+    visit event_task_path(task)
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).not_to have_content('Tarefa inicial')
+  end
+
+  it 'not see task for other users' do
+    first_user = create(:user, first_name: 'João')
+    first_user_task = first_user.event_tasks.create!(name: 'Dev week', description: 'Tarefa inicial para estudo prévio da palestra')
+    second_user = create(:user, first_name: 'Luiz')
+
+    login_as second_user
+    visit event_task_path(first_user_task)
+
+    expect(current_path).to eq events_path
+    expect(page).to have_content ('Acesso não autorizado.')
+  end
+end


### PR DESCRIPTION
Usuário vê detalhes das tarefas e seu conteúdo anexado.
![Captura de tela 2025-01-22 153229](https://github.com/user-attachments/assets/c3af7fd1-9c25-4a83-bd3a-5858c69f76fd)

Usuário clica no conteúdo e vê seus detalhes:
![Captura de tela 2025-01-22 153242](https://github.com/user-attachments/assets/d91d573f-075b-4987-ac20-213006f5fbdb)

Usuário vê uma mensagem caso não haja conteúdos relacionados a terafa:
![image](https://github.com/user-attachments/assets/136a592d-bf45-41ec-bd1f-d20a18f1e65a)

Resolve #46