### PR TITLE
feat: user edit task

### DIFF
--- a/app/controllers/event_tasks_controller.rb
+++ b/app/controllers/event_tasks_controller.rb
@@ -1,7 +1,8 @@
 class EventTasksController < ApplicationController
   before_action :authenticate_user!
   before_action :check_event_content_owner, only: :create
-  before_action :set_event_task, only: %i[ show edit ]
+  before_action :set_event_task, only: %i[ show edit update ]
+  before_action :set_event_contents, only: %i[ new create edit update ]
 
   def index
     @event_tasks = current_user.event_tasks
@@ -9,23 +10,27 @@ class EventTasksController < ApplicationController
 
   def new
     @event_task = current_user.event_tasks.build
-    @contents = current_user.event_contents
   end
 
-  def show; end
-
-  def edit
-  end
-
-  def update
-  end
   def create
     @event_task = current_user.event_tasks.build(event_task_params)
-    @contents = current_user.event_contents
     return redirect_to event_tasks_path, notice: "Tarefa cadastrada com sucesso!" if @event_task.save
 
     flash.now["alert"] = "Falha ao criar tarefa."
     render :new, status: :unprocessable_entity
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @event_task.update(event_task_params)
+      redirect_to @event_task, notice: "Tarefa atualizada com sucesso!"
+    else
+      flash.now[:alert] = "Não foi possível atualizar sua tarefa."
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
@@ -38,10 +43,13 @@ class EventTasksController < ApplicationController
     begin
       @event_task = current_user.event_tasks.find(params[:id])
     rescue
-      redirect_to events_path, notice: "Acesso não autorizado."
+      redirect_to events_path, alert: "Acesso não autorizado."
     end
   end
 
+  def set_event_contents
+    @contents = current_user.event_contents
+  end
 
   def check_event_content_owner
     return unless current_user.event_contents.present?

--- a/app/views/event_tasks/_form.html.erb
+++ b/app/views/event_tasks/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with model: event_task, data: { turbo: false } do |f| %>
+  <div>
+    <%= f.label :name, class: 'label-primary' %>
+    <%= f.text_field :name, class: 'field-primary' %>
+    <% if event_task.errors[:name].any? %> 
+      <span class="text-red-500 text-sm"><%= event_task.errors[:name].first %></span>
+    <% end %>
+  </div>
+  <div>
+    <%= f.label :description, class: 'label-primary' %>
+    <%= f.text_area :description, class: 'text-area' %>
+    <% if event_task.errors[:description].any? %> 
+      <span class="text-red-500 text-sm"><%= event_task.errors[:description].first %></span>
+    <% end %>
+  </div>
+  <div>
+    <%= f.label :certificate_requirement, class: 'label-primary' %>
+    <%= f.collection_radio_buttons :certificate_requirement, EventTask.certificate_requirements.keys.map { |key| [EventTask.human_enum_name(:certificate_requirement, key), key] }, :second, :first do |b| %>
+      <div>
+        <%= b.radio_button %>
+        <%= b.label %>
+      </div>
+    <% end %>
+    <% if event_task.errors[:certificate_requirement].any? %> 
+      <span class="text-red-500 text-sm"><%= event_task.errors[:certificate_requirement].first %></span>
+    <% end %>
+  </div>
+  <div class="col-span-2">
+        <%= f.label :event_content_ids, class: "block text-sm font-medium text-gray-700" %>
+          <% if contents.blank? %>
+            <p> <%= t('.no_contents') %></p>
+          <% else %>
+            <%= f.collection_check_boxes(:event_content_ids, contents, :id, :title) do |b| %>
+                <%= b.check_box %>
+                <%= b.label(class: "text-sm text-gray-900 mr-2") %>
+            <% end %>
+          <% end %>
+      </div>
+  <div>
+    <%= f.submit t('.save'), class: 'btn-primary'%>
+  </div>
+<% end %>
+

--- a/app/views/event_tasks/edit.html.erb
+++ b/app/views/event_tasks/edit.html.erb
@@ -1,0 +1,5 @@
+<h2 class='heading-2'> <%= t('.title') %></h2>
+
+<div>
+  <%= render 'form', event_task: @event_task, contents: @contents%> 
+</div>

--- a/app/views/event_tasks/new.html.erb
+++ b/app/views/event_tasks/new.html.erb
@@ -1,45 +1,5 @@
 <h2 class='heading-2'> <%= t('.title') %></h2>
 
-<%= form_with model: @event_task, data: { turbo: false } do |f| %>
-  <div>
-    <%= f.label :name, class: 'label-primary' %>
-    <%= f.text_field :name, class: 'field-primary' %>
-    <% if @event_task.errors[:name].any? %> 
-      <span class="text-red-500 text-sm"><%= @event_task.errors[:name].first %></span>
-    <% end %>
-  </div>
-  <div>
-    <%= f.label :description, class: 'label-primary' %>
-    <%= f.text_area :description, class: 'text-area' %>
-    <% if @event_task.errors[:description].any? %> 
-      <span class="text-red-500 text-sm"><%= @event_task.errors[:description].first %></span>
-    <% end %>
-  </div>
-  <div>
-    <%= f.label :certificate_requirement, class: 'label-primary' %>
-    <%= f.collection_radio_buttons :certificate_requirement, EventTask.certificate_requirements.keys.map { |key| [EventTask.human_enum_name(:certificate_requirement, key), key] }, :second, :first do |b| %>
-      <div>
-        <%= b.radio_button %>
-        <%= b.label %>
-      </div>
-    <% end %>
-    <% if @event_task.errors[:certificate_requirement].any? %> 
-      <span class="text-red-500 text-sm"><%= @event_task.errors[:certificate_requirement].first %></span>
-    <% end %>
-  </div>
-  <div class="col-span-2">
-        <%= f.label :event_content_ids, class: "block text-sm font-medium text-gray-700" %>
-          <% if @contents.blank? %>
-            <p> <%= t('.no_contents') %></p>
-          <% else %>
-            <%= f.collection_check_boxes(:event_content_ids, @contents, :id, :title) do |b| %>
-                <%= b.check_box %>
-                <%= b.label(class: "text-sm text-gray-900 mr-2") %>
-            <% end %>
-          <% end %>
-      </div>
-  <div>
-    <%= f.submit t('.save'), class: 'btn-primary'%>
-  </div>
-<% end %>
-
+<div>
+  <%= render 'form', event_task: @event_task, contents: @contents %>
+</div>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -2,8 +2,8 @@ pt-BR:
   event_tasks:
     new:
       title: 'Cadastrar Tarefa'
-      no_contents: 'Nenhum conteúdo cadastrado'
-      save: 'Salvar'
+    edit:
+      title: 'Editar Tarefa'
     index:
       my_tasks: 'Minhas Tarefas'
       new_task: 'Cadastrar Tarefa'
@@ -17,3 +17,6 @@ pt-BR:
       no_content_attetched: 'Nenhum conteúdo vinculado.'
       attatched_contents: 'Conteúdos vinculados:'
       content: 'Conteúdo'
+    form:
+      no_contents: 'Nenhum conteúdo cadastrado'
+      save: 'Salvar'

--- a/spec/requests/event_task/user_edit_event_task_spec.rb
+++ b/spec/requests/event_task/user_edit_event_task_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'User edit content' do
+  it 'and try to edit another user task' do
+    first_user = create(:user, first_name: 'Erika')
+    task = first_user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    second_user = create(:user, first_name: 'Otávio')
+
+    login_as second_user
+    patch(event_task_path(task.id), params: { event_task: { name: 'Atividades avançadas', description: 'Descrição falsa' } })
+
+    expect(response).to redirect_to events_path
+    expect(task.name).to eq 'Tarefa inicial'
+  end
+end

--- a/spec/system/event_content/user_edit_event_content_spec.rb
+++ b/spec/system/event_content/user_edit_event_content_spec.rb
@@ -33,7 +33,6 @@ describe 'User edit event content', type: :system, js: true do
     click_on 'Meus Conteúdos'
     click_on 'Dev week'
     find("#pencil_edit").click
-    save_page
     fill_in 'Título', with: 'Workshop POO'
     fill_in_rich_text_area 'Descrição', with: 'Conetúdo para auxiliar o workshop POO'
     attach_file('Arquivos', [ Rails.root.join('spec/fixtures/puts.png') ])

--- a/spec/system/event_task/user_edit_task_details_spec.rb
+++ b/spec/system/event_task/user_edit_task_details_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+describe 'user edit task', type: :system, js: true do
+  it 'and must be authenticated' do
+    user = create(:user, first_name: 'João')
+    task = user.event_tasks.create!(name: 'Tarefa Ruby', description: 'Tarefa para iniciantes')
+
+    visit edit_event_task_path(task)
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
+
+  it 'with success' do
+    user = create(:user)
+    content = create(:event_content, title: 'My content', description: 'My own content', user: user)
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    EventTaskContent.create!(event_content: content, event_task: task)
+    create(:event_content, title: 'Second Content', description: 'My second content', user: user)
+
+    login_as user
+    visit event_tasks_path
+    click_on 'Tarefa inicial'
+    find("#pencil_edit").click
+    check 'My content'
+    check 'Second Content'
+    fill_in 'Título', with: 'Conteúdo editado'
+    fill_in 'Descrição', with: 'Descrição editada'
+    choose 'Obrigatória'
+    click_on 'Salvar'
+
+    expect(current_path).to eq event_task_path(task)
+    expect(page).to have_content 'Tarefa atualizada com sucesso!'
+    expect(page).to have_content 'Conteúdo editado'
+    expect(page).to have_content 'Descrição editada'
+    expect(page).to have_content 'Obrigatória'
+    expect(page).to have_link 'Second Content'
+    expect(page).not_to have_link 'My Content'
+  end
+
+  it 'failure if title or description are empty' do
+    user = create(:user)
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+
+    login_as user
+    visit event_task_path(task)
+    find("#pencil_edit").click
+    fill_in 'Título', with: ''
+    fill_in 'Descrição', with: ''
+    choose 'Obrigatória'
+    click_on 'Salvar'
+
+    expect(page).to have_content 'Não foi possível atualizar sua tarefa.'
+    expect(task.optional?).to be true
+  end
+
+  it 'and must be the owner' do
+    user = create(:user)
+    user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    user2 = create(:user)
+    task2 = user2.event_tasks.create!(name: 'Tarefa Ruby Básica', description: 'Principios TDD')
+
+    login_as user
+    visit edit_event_task_path(task2)
+
+    expect(current_path).to eq events_path
+    expect(page).to have_content 'Acesso não autorizado.'
+  end
+end


### PR DESCRIPTION
Usuário clica em editar tarefa:
![Captura de tela 2025-01-22 165857](https://github.com/user-attachments/assets/7caf64b9-7e14-475b-9b32-d1267c655127)

Usuário edita o título, descrição, se é obrigatória e os conteúdos da terafa:
![Captura de tela 2025-01-22 165905](https://github.com/user-attachments/assets/65c06cbc-1dc5-4306-92bc-409cc1fa0132)

Usuário recebe um alerta caso os campos obrigatórios (título e descrição) fiquem em branco:
![Captura de tela 2025-01-22 165913](https://github.com/user-attachments/assets/0251277d-093d-427c-b590-091d65d79db6)

Usuário recebe um aviso caso a edição seja bem sucedida:
![Captura de tela 2025-01-22 170304](https://github.com/user-attachments/assets/f4562994-4d1a-4250-878c-b6c8bdf32393)


Resolve #16 