### PR TITLE
Fix/53 service test correction: Correção de bugs identicados no arquivo de testes find_event_service.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,8 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.0)
-    irb (1.14.3)
+    irb (1.15.0)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.13.0)
@@ -210,6 +211,9 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     propshaft (1.1.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,7 @@ class Event
 
   attr_accessor :id, :name, :url, :description, :start_date, :end_date, :event_type, :location, :participant_limit, :status
 
+  @@instances = []
   def initialize(id:, name:, url:, description:, start_date:, end_date:, event_type:, location:, participant_limit:, status:)
     @id = id
     @name = name
@@ -14,6 +15,7 @@ class Event
     @location = location
     @participant_limit = participant_limit
     @status = status
+    @@instances << self
   end
 
 
@@ -41,5 +43,13 @@ class Event
 
   def self.find(id)
     ExternalEventApi::FindEventService.call(id)
+  end
+
+  def self.count
+    @@instances.size
+  end
+
+  def self.last
+    @@instances.last
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -52,4 +52,8 @@ class Event
   def self.last
     @@instances.last
   end
+
+  def self.delete_all
+    @@instances = []
+  end
 end

--- a/app/services/external_event_api/user_find_email_service.rb
+++ b/app/services/external_event_api/user_find_email_service.rb
@@ -3,7 +3,7 @@ class ExternalEventApi::UserFindEmailService
     @email = email
   end
 
-  def self.find_email
+  def self.find_email(email)
     new(email).find_email
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -83,4 +83,15 @@ describe Event do
       expect(Event.last).to be_nil
     end
   end
+
+  context '.delete_all' do
+    it 'must be delete all instances' do
+      4.times do |n|
+        build(:event, name: "Dev show #{n}", description: "Take #{n}")
+      end
+      Event.delete_all
+
+      expect(Event.count).to eq 0
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -45,4 +45,13 @@ describe Event do
 
       expect(logger).to have_received(:error).with("Erro: ")
     end
+
+  context '.count' do
+    it 'should return a count of all instances' do
+      events = []
+      3.times { events << build(:event) }
+
+      expect(Event.count).to eq 3
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -48,10 +48,39 @@ describe Event do
 
   context '.count' do
     it 'should return a count of all instances' do
-      events = []
-      3.times { events << build(:event) }
+      Event.delete_all
+      10.times do
+        build(:event)
+      end
 
-      expect(Event.count).to eq 3
+      expect(Event.count).to eq 10
+    end
+
+    it 'should return zero if there are no instances' do
+      Event.delete_all
+      expect(Event.count).to eq 0
+    end
+  end
+
+  context '.last' do
+    it 'must return the last instance' do
+      Event.delete_all
+      4.times do |n|
+        build(:event, name: "Dev show #{n}", description: "Take #{n}")
+      end
+      build(:event, name: 'Tech Week', description: 'Desenvolvimento guiado por testes.')
+
+      last_event = Event.last
+
+      expect(last_event.name).to eq 'Tech Week'
+      expect(last_event.description).to eq 'Desenvolvimento guiado por testes.'
+      expect(last_event.inspect).not_to include 'Dev show'
+      expect(last_event.inspect).not_to include 'Take'
+    end
+
+    it 'should return nil if there are no instances' do
+      Event.delete_all
+      expect(Event.last).to be_nil
     end
   end
 end

--- a/spec/services/find_event_service_spec.rb
+++ b/spec/services/find_event_service_spec.rb
@@ -15,11 +15,11 @@ describe ExternalEventApi::FindEventService do
         "participant_limit": 20,
         "status": "published"
       }
-      service = ExternalEventApi::FindEventService.new(json_event.id)
-      response = instance_double(Faraday::Response, success?: true, body: json_event)
+      service = ExternalEventApi::FindEventService.new(json_event['id'])
+      response = instance_double(Faraday::Response, success?: true, body: json_event.to_json)
       allow(Faraday).to receive(:get).and_return(response)
 
-      expect { service.find }.to change(Event, :count).by(1)
+      expect { service.call }.to change(Event, :count).by(1)
       event = Event.last
       expect(event.name).to eq 'Event1'
       expect(event.url).to eq 'meuevento.com/eventos/Event1'
@@ -37,14 +37,14 @@ describe ExternalEventApi::FindEventService do
       response = instance_double(Faraday::Response, success?: false, body: {})
       allow(Faraday).to receive(:get).and_return(response)
 
-      expect { service.find }.to change(Event, :count).by(0)
+      expect { service.call }.to change(Event, :count).by(0)
     end
 
     it 'when Connection Failed exception happens' do
-      ExternalEventApi::FindEventService.new(1)
+      service = ExternalEventApi::FindEventService.new(1)
       allow(Faraday).to receive(:get).and_raise(Faraday::ConnectionFailed)
-
       expect(Rails.logger).to receive(:error).with(instance_of(Faraday::ConnectionFailed))
+      expect(service.call).to be_nil
     end
   end
 end

--- a/spec/services/user_find_email_spec.rb
+++ b/spec/services/user_find_email_spec.rb
@@ -4,11 +4,11 @@ describe ExternalEventApi::UserFindEmailService do
   context '#find_email' do
     it 'when API return success' do
       email = 'test@email.com'
-      service = ExternalEventApi::UserFindEmailService.new(email)
       response = instance_double(Faraday::Response, success?: true)
       allow(Faraday).to receive(:get).and_return(response)
+      service = ExternalEventApi::UserFindEmailService.find_email(email)
 
-      expect(service.find_email).to eq(true)
+      expect(service).to eq(true)
     end
 
     it 'when API return not found' do


### PR DESCRIPTION
Ajustes em testes de serviço com adição de novas funcionalidades a classe Event, como os métodos count, para o retorno de contagens das instâncias; o método last, para retorno da última instância; e o método delete_all, para a exclusão de todas as instâncias. O método delete_all em especial, demonstrou-se necessário devido a um comportamento indesejado do Factory Bot, o comportamento se trata da persistência em memória de instâncias da classe Event, o que impossibilitava a realização de testes de contagem ou listagem de instâncias.

![image](https://github.com/user-attachments/assets/4260032c-e3f3-40f6-8aa9-4fc3b05b821d)

Resolve #53
