### PR TITLE
Fix/ Ajustes visuais na tela de detalhes de conteúdo e tarefas, melhoria de navegabilidade, padronização exibição de erros na aplicação

### DIFF
--- a/app/views/event_contents/_form.html.erb
+++ b/app/views/event_contents/_form.html.erb
@@ -12,12 +12,12 @@
     <%= f.rich_textarea :description, class: 'text-area' %>
   </div>
 
-  <% if event_content.files.attached? %>
+  <% if event_content.files.any? { |file| file.persisted? } %>
     <div class="mt-5 mb-5">
-      <strong>Arquivos já anexados:</strong>
+      <strong><%= t('.files_attached') %></strong>
       <% event_content.files.each do |file| %>
         <div>
-          <%= file.filename %>
+          <%= file.filename if file.persisted? %>
         </div>
       <% end %>
     </div>
@@ -26,8 +26,11 @@
   <div class="mb-3">
     <%= f.label :files, 'Arquivos' %>
     <%= f.file_field :files, multiple: true %>
+    <% if event_content.errors[:base].any? %> 
+      <div class="text-red-500 text-sm"><%= event_content.errors[:base].first %></div>
+    <% end %>
   </div>
-
+  
   <%= f.submit class: 'btn-primary' %>
   <%= link_to 'Cancelar', event_content, class: 'btn-primary' %>
 <% end %>

--- a/app/views/event_contents/_form.html.erb
+++ b/app/views/event_contents/_form.html.erb
@@ -2,6 +2,9 @@
   <div class="field">
     <%= f.label :title, class: 'label-primary' %>
     <%= f.text_field :title, class: 'field-primary' %>
+    <% if event_content.errors[:title].any? %> 
+      <span class="text-red-500 text-sm"><%= event_content.errors[:title].first %></span>
+    <% end %>
   </div>
 
   <div>

--- a/app/views/event_contents/_form.html.erb
+++ b/app/views/event_contents/_form.html.erb
@@ -3,7 +3,7 @@
     <%= f.label :title, class: 'label-primary' %>
     <%= f.text_field :title, class: 'field-primary' %>
     <% if event_content.errors[:title].any? %> 
-      <span class="text-red-500 text-sm"><%= event_content.errors[:title].first %></span>
+      <span class="text-red-500 text-sm"><%= event_content.errors.full_messages_for(:title).first %></span>
     <% end %>
   </div>
 
@@ -27,7 +27,7 @@
     <%= f.label :files, 'Arquivos' %>
     <%= f.file_field :files, multiple: true %>
     <% if event_content.errors[:base].any? %> 
-      <div class="text-red-500 text-sm"><%= event_content.errors[:base].first %></div>
+      <div class="text-red-500 text-sm"><%= event_content.errors.full_messages_for(:base).first %></div>
     <% end %>
   </div>
   

--- a/app/views/event_contents/edit.html.erb
+++ b/app/views/event_contents/edit.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/errors', object: @event_content %>
 <h2 class='heading-2'>Edite <%= @event_content.title.capitalize %></h2>
 
 <%= render 'form', event_content: @event_content %>

--- a/app/views/event_contents/new.html.erb
+++ b/app/views/event_contents/new.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/errors', object: @event_content %>
 <h2 class='heading-2'>Cadastre seus conteúdos</h2>
 
 <%= render 'form', event_content: @event_content %>

--- a/app/views/event_contents/show.html.erb
+++ b/app/views/event_contents/show.html.erb
@@ -21,7 +21,7 @@
         <% elsif file.content_type == 'application/pdf' %>
           <%= link_to(url_for(file), target: '_blank', class: 'card max-h-96 flex flex-col justify-center items-center' ) do %>
             <%= image_tag("pdf.png", class: 'w-2/3 h-2/3') %>
-            <p>Visualizar PDF: <%= "#{file.filename.to_s}" %></p>
+            <p><%= t('.view_pdf') %> <%= "#{file.filename.to_s}" %></p>
           <% end %>
         <% else %>
           <%= link_to "Arquivo #{file.filename.to_s}", url_for(file), target: '_blank', class: 'card max-h-96' %>
@@ -31,7 +31,27 @@
 
   <% else %>
     <div class="mt-10">
-      <strong>Não há arquivos anexados a esse conteúdo.</strong>
+      <strong><%=t('.no_files_attached')%></strong>
     </div>
+  <% end %>
+</div>
+
+<div>
+  <% if @event_content.event_tasks.any? %>
+    <div>
+      <strong><%= t('.attached_to_tasks') %></strong>
+      <div class="card_container mb-10">
+        <% @event_content.event_tasks.each do |task| %>
+          <%= link_to(task, class: "card") do %>
+            <div>
+              <p class="card_title_2"> <%= t('.task') %> </p>
+              <h3 class="card_title"><%= task.name %></h3>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <div> <%=t('.no_tasks_attached')%> </div>
   <% end %>
 </div>

--- a/app/views/event_tasks/_form.html.erb
+++ b/app/views/event_tasks/_form.html.erb
@@ -38,6 +38,6 @@
       </div>
   <div>
     <%= f.submit t('.save'), class: 'btn-primary'%>
+    <%= link_to 'Cancelar', event_task, class: 'btn-primary' %>
   </div>
 <% end %>
-

--- a/app/views/event_tasks/show.html.erb
+++ b/app/views/event_tasks/show.html.erb
@@ -20,11 +20,11 @@
 <div class="mt-5">
   <% if @event_task.event_contents.any? %>
     <div>
-      <strong><%= t('.attatched_contents') %></strong>
+      <strong><%= t('.attached_contents') %></strong>
       <div class="card_container">
         <% @event_task.event_contents.each do |content| %>
           <%= link_to(content, class: "card") do %>
-            <div >
+            <div>
               <p class="card_title_2"><%= t('.content') %></p>
               <h3 class="card_title"><%= content.title %></h3>
             </div>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -20,3 +20,6 @@ pt-BR:
     form:
       no_contents: 'Nenhum conteúdo cadastrado'
       save: 'Salvar'
+  event_contents:
+    form:
+      files_attached: 'Arquivos já anexados:'

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -15,7 +15,7 @@ pt-BR:
       mandatory: Obrigatória
       optional: Opcional
       no_content_attetched: 'Nenhum conteúdo vinculado.'
-      attatched_contents: 'Conteúdos vinculados:'
+      attached_contents: 'Conteúdos vinculados:'
       content: 'Conteúdo'
     form:
       no_contents: 'Nenhum conteúdo cadastrado'
@@ -23,3 +23,9 @@ pt-BR:
   event_contents:
     form:
       files_attached: 'Arquivos já anexados:'
+    show:
+      attached_to_tasks: 'Tarefas que utilizam este conteúdo:'
+      task: 'Tarefa'
+      no_tasks_attached: 'Esse conteúdo não foi associado a nenhuma tarefa.'
+      no_files_attached: 'Não há arquivos anexados a esse conteúdo.'
+      view_pdf: 'Visualizar PDF:'

--- a/spec/system/event_content/user_edit_event_content_spec.rb
+++ b/spec/system/event_content/user_edit_event_content_spec.rb
@@ -64,4 +64,28 @@ describe 'User edit event content', type: :system, js: true do
     expect(page).to have_content 'Não foi possível atualizar seu Conteúdo.'
     expect(page).to have_content 'Título não pode ficar em branco'
   end
+
+  it 'and cancels' do
+    user = create(:user, first_name: 'João')
+    image_1 = fixture_file_upload(Rails.root.join('spec/fixtures/mark_zuckerberg.jpeg'))
+    content = user.event_contents.create!(title: 'Dev week', description: 'Conteúdo da palestra de 01/01', files: [ image_1 ])
+
+    login_as user
+    visit root_path
+    click_on 'Meus Conteúdos'
+    click_on 'Dev week'
+    find("#pencil_edit").click
+    fill_in 'Título', with: 'Workshop POO'
+    fill_in_rich_text_area 'Descrição', with: 'Conetúdo para auxiliar o workshop POO'
+    attach_file('Arquivos', [ Rails.root.join('spec/fixtures/puts.png') ])
+    click_on 'Cancelar'
+
+    expect(current_path).to eq event_content_path(content)
+    expect(page).to have_content 'Dev week'
+    expect(page).not_to have_content 'Workshop POO'
+    expect(page).to have_content 'Conteúdo da palestra de 01/01'
+    expect(page).not_to have_content 'Conetúdo para auxiliar o workshop POO'
+    expect(page).to have_css("img[src*='mark_zuckerberg.jpeg']")
+    expect(page).not_to have_css("img[src*='puts.png']")
+  end
 end

--- a/spec/system/event_content/user_edit_event_content_spec.rb
+++ b/spec/system/event_content/user_edit_event_content_spec.rb
@@ -65,6 +65,34 @@ describe 'User edit event content', type: :system, js: true do
     expect(page).to have_content 'Título não pode ficar em branco'
   end
 
+  it 'and try to add a sixth file' do
+    user = create(:user)
+    files = [ Rails.root.join('spec/fixtures/mark_zuckerberg.jpeg'),
+              Rails.root.join('spec/fixtures/capi.png'),
+              Rails.root.join('spec/fixtures/puts.png'),
+              Rails.root.join('spec/fixtures/joker.mp4'),
+              Rails.root.join('spec/fixtures/nota-ufjf.pdf')
+            ]
+    user.event_contents.create!(title: 'Dev week', description: 'Conteúdo da palestra de 01/01', files: files)
+
+    login_as user
+    visit root_path
+    click_on 'Meus Conteúdos'
+    click_on 'Dev week'
+    find("#pencil_edit").click
+    attach_file('Arquivos', Rails.root.join('spec/fixtures/Reunião.pdf'))
+    click_on 'Atualizar Conteúdo'
+
+    expect(page).to have_content 'Não foi possível atualizar seu Conteúdo.'
+    expect(page).to have_content 'Não é possível enviar mais que 5 arquivos.'
+    expect(page).to have_content 'mark_zuckerberg.jpeg'
+    expect(page).to have_content 'capi.png'
+    expect(page).to have_content 'joker.mp4'
+    expect(page).to have_content 'puts.png'
+    expect(page).to have_content 'nota-ufjf.pdf'
+    expect(page).not_to have_content 'Reunião.pdf'
+  end
+
   it 'and cancels' do
     user = create(:user, first_name: 'João')
     image_1 = fixture_file_upload(Rails.root.join('spec/fixtures/mark_zuckerberg.jpeg'))

--- a/spec/system/event_content/user_register_a_content_spec.rb
+++ b/spec/system/event_content/user_register_a_content_spec.rb
@@ -88,4 +88,19 @@ describe 'User register a content', type: :system, js: true do
     expect(page).to have_content 'Falha ao registrar o conteúdo.'
     expect(page).to have_content 'Título não pode ficar em branco'
   end
+
+  it 'and cancels' do
+    user = create(:user, first_name: 'João')
+
+    login_as user
+    visit root_path
+    click_on 'Meus Conteúdos'
+    click_on 'Cadastrar Conteúdo'
+    fill_in 'Título', with: 'Ruby para iniciantes'
+    fill_in_rich_text_area 'Descrição', with: 'Um guia sobre o mundo dos desenvolvedores felizes.'
+    click_on 'Cancelar'
+
+    expect(EventContent.count).to eq 0
+    expect(current_path).to eq event_contents_path
+  end
 end

--- a/spec/system/event_content/user_register_a_content_spec.rb
+++ b/spec/system/event_content/user_register_a_content_spec.rb
@@ -54,6 +54,12 @@ describe 'User register a content', type: :system, js: true do
     expect(EventContent.count).to eq 0
     expect(page).to have_content 'Falha ao registrar o conteúdo.'
     expect(page).to have_content 'Não é possível enviar mais que 5 arquivos.'
+    expect(page).not_to have_content 'mark_zuckerberg.jpeg'
+    expect(page).not_to have_content 'capi.png'
+    expect(page).not_to have_content 'puts.png'
+    expect(page).not_to have_content 'joker.mp4'
+    expect(page).not_to have_content 'nota-ufjf.pdf'
+    expect(page).not_to have_content 'Reunião.pdf'
   end
 
   it 'failure with file larger than 50mb' do
@@ -71,6 +77,8 @@ describe 'User register a content', type: :system, js: true do
     expect(EventContent.count).to eq 0
     expect(page).to have_content 'Falha ao registrar o conteúdo.'
     expect(page).to have_content 'Não é possível enviar arquivos com mais de 50mb.'
+    expect(page).not_to have_content 'Arquivos já anexados:'
+    expect(page).not_to have_content 'Topicos de Fisica.pdf'
   end
 
   it 'failure if title is empty' do

--- a/spec/system/event_content/user_view_content_spec.rb
+++ b/spec/system/event_content/user_view_content_spec.rb
@@ -46,4 +46,43 @@ describe 'User view a content' do
 
     expect(current_path).to eq new_user_session_path
   end
+
+  it 'and view all tasks where this content is used' do
+    user = create(:user, first_name: 'João')
+    event_content = user.event_contents.create!(title: 'Dev week', description: 'Conteúdo da palestra de 01/01')
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    EventTaskContent.create!(event_content: event_content, event_task: task)
+    task2 = user.event_tasks.create!(name: 'Aprofundamento', description: 'pós créditos da palestra')
+    EventTaskContent.create!(event_content: event_content, event_task: task2)
+
+    login_as user
+    visit event_content_path(event_content)
+
+    expect(page).to have_content 'Tarefas que utilizam este conteúdo:'
+    expect(page).to have_link 'Tarefa inicial'
+    expect(page).to have_link 'Aprofundamento'
+  end
+
+  it 'and access task details' do
+    user = create(:user, first_name: 'João')
+    event_content = user.event_contents.create!(title: 'Dev week', description: 'Conteúdo da palestra de 01/01')
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    EventTaskContent.create!(event_content: event_content, event_task: task)
+
+    login_as user
+    visit event_content_path(event_content)
+    click_on 'Tarefa inicial'
+
+    expect(current_path).to eq event_task_path(task)
+  end
+
+  it 'and not see tasks for this content' do
+    user = create(:user, first_name: 'João')
+    event_content = user.event_contents.create!(title: 'Dev week', description: 'Conteúdo da palestra de 01/01')
+
+    login_as user
+    visit event_content_path(event_content)
+
+    expect(page).to have_content 'Esse conteúdo não foi associado a nenhuma tarefa.'
+  end
 end

--- a/spec/system/event_task/user_edit_task_details_spec.rb
+++ b/spec/system/event_task/user_edit_task_details_spec.rb
@@ -66,4 +66,30 @@ describe 'user edit task', type: :system, js: true do
     expect(current_path).to eq events_path
     expect(page).to have_content 'Acesso não autorizado.'
   end
+
+  it 'click on edit and cancel' do
+    user = create(:user)
+    content = create(:event_content, title: 'My content', description: 'My own content', user: user)
+    task = user.event_tasks.create!(name: 'Tarefa inicial', description: 'Desafio para iniciantes')
+    EventTaskContent.create!(event_content: content, event_task: task)
+    create(:event_content, title: 'Second Content', description: 'My second content', user: user)
+
+    login_as user
+    visit event_tasks_path
+    click_on 'Tarefa inicial'
+    find("#pencil_edit").click
+    check 'My content'
+    check 'Second Content'
+    fill_in 'Título', with: 'Conteúdo editado'
+    fill_in 'Descrição', with: 'Descrição editada'
+    choose 'Obrigatória'
+    click_on 'Cancelar'
+
+    expect(current_path).to eq event_task_path(task)
+    expect(page).to have_link 'My content'
+    expect(page).to have_content 'Opcional'
+    expect(page).not_to have_link 'Second Content'
+    expect(page).not_to have_link 'Conteúdo editado'
+    expect(page).not_to have_content 'Descrição editada'
+  end
 end

--- a/spec/system/event_task/user_register_task_spec.rb
+++ b/spec/system/event_task/user_register_task_spec.rb
@@ -8,7 +8,6 @@ describe 'User register tasks' do
     expect(current_path).to eq new_user_session_path
   end
 
-
   it 'with success' do
     user = create(:user)
     create(:event_content, title: 'My content', description: 'My own content', user: user)
@@ -79,5 +78,22 @@ describe 'User register tasks' do
     visit new_event_task_path
 
     expect(page).to have_checked_field('Opcional')
+  end
+
+  it 'and cancel' do
+    user = create(:user)
+    create(:event_content, title: 'My content', description: 'My own content', user: user)
+
+    login_as user
+    visit new_event_task_path
+
+    fill_in 'Título', with: 'Tarefa 01'
+    fill_in 'Descrição', with: 'Lorem ipsum'
+    choose 'Obrigatória'
+    check 'My content'
+    click_on 'Cancelar'
+
+    expect(EventTask.count).to eq 0
+    expect(current_path).to eq event_tasks_path
   end
 end


### PR DESCRIPTION
Usuário agora conta com um botão de cancelar na tela de edição/criação de conteúdos e tarefas:
![image](https://github.com/user-attachments/assets/0b105fef-a420-4062-8083-e8150023768e)

Foi corrigido o bug visual no qual o upload mesmo não sendo válido (5 arquivos no máximo ou 50mb) exibia estes arquivos como  'Arquivos já anexados ao conteúdo'.

Arruma exibição do erro ao tentar enviar um novo arquivo já tendo 5 arquivos registrados para um conteúdo:
![image](https://github.com/user-attachments/assets/7b6e4d32-419d-435a-9add-c932346c327e)

Arruma exibição do erro ao tentar enviar 6 arquivos ou arquivos que excedam 50mb:
![Captura de tela 2025-01-23 171213](https://github.com/user-attachments/assets/947d2664-af38-43f4-9c75-59c5574cd57d)

Usuário agora ao acessar um conteúdo específico conta com uma lista das tarefas na qual esta conteúdo foi utilizado e consegue clicar na tarefa e ir para detalhes desta.
![image](https://github.com/user-attachments/assets/cb1520b5-a960-4eca-a008-ea1c1c32360e)

Resolve #52 