### PR TITLE
feat: Adiciona filtro (email) de participante na rota de eventos

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   before_action :authenticate_user!
   def index
-    @events = Event.all
+    @events = Event.all(current_user.email)
   end
 
   def show

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,7 +6,7 @@ class ProfilesController < ApplicationController
     @profile = Profile.find_by(username: params[:username])
     return redirect_to events_path, alert: t('profiles.show.error', profile: params[:username]) if @profile.nil? && user_signed_in?
     return redirect_to root_path, alert: t('profiles.show.error', profile: params[:username]) if @profile.nil?
-    @events = Event.all
+    @events = Event.all(@profile.user.email)
   end
   def new
     @profile = current_user.build_profile

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,10 +19,10 @@ class Event
   end
 
 
-  def self.all
+  def self.all(email)
     result = []
     begin
-      response = Faraday.get("http://localhost:3001/api/v1/events")
+      response = Faraday.get("http://localhost:3001/events/speaker_events?email=#{email}")
 
       if response.status == 200
         json = JSON.parse(response.body)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,10 +4,10 @@ describe Event do
   context '.all' do
     it 'should get all event information' do
       json = File.read(Rails.root.join('spec/support/events_data.json'))
-      url = 'http://localhost:3001/api/v1/events'
+      url = "http://localhost:3001/events/speaker_events?email=teste@email.com"
       response = double('faraday_response', body: json, status: 200)
       allow(Faraday).to receive(:get).with(url).and_return(response)
-      result = Event.all
+      result = Event.all('teste@email.com')
       expect(result.length).to eq 2
       expect(result[0].name).to eq 'Event1'
       expect(result[0].url).to eq ''
@@ -33,7 +33,7 @@ describe Event do
       logger = Rails.logger
       allow(logger).to receive(:error)
       allow(Faraday).to receive(:get).and_raise(Faraday::ConnectionFailed)
-      Event.all
+      Event.all('teste@email.com')
 
       expect(logger).to have_received(:error).with(instance_of(Faraday::ConnectionFailed))
     end
@@ -42,7 +42,7 @@ describe Event do
       logger = Rails.logger
       allow(logger).to receive(:error)
       allow(Faraday).to receive(:get).and_raise(StandardError)
-      Event.all
+      Event.all('teste@email.com')
 
       expect(logger).to have_received(:error).with("Erro: StandardError")
     end


### PR DESCRIPTION
Alteração de rota em model para consumo de Api de teste. Agora endpoint conta com parâmetro para de email para listar eventos com base no Palestrante. Resolve #8 