### PR TITLE
feat: Curriculo do item da agenda é gerado automaticamente ao acessar a página do item da agenda pela primeira vez

### DIFF
--- a/app/controllers/schedule_items_controller.rb
+++ b/app/controllers/schedule_items_controller.rb
@@ -3,6 +3,13 @@ class ScheduleItemsController < ApplicationController
 
   def show
     @schedule_item = ScheduleItem.find(params[:id], current_user.email)
+    generate_curriculum if @schedule_item
     redirect_to events_path, alert: t('.not_found') unless @schedule_item
+  end
+
+  private
+
+  def generate_curriculum
+    @curriculum = Curriculum.find_or_create_by(user_id: current_user.id, schedule_item_code: @schedule_item.id)
   end
 end

--- a/app/models/curriculum.rb
+++ b/app/models/curriculum.rb
@@ -1,0 +1,3 @@
+class Curriculum < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20250128182425_create_curriculums.rb
+++ b/db/migrate/20250128182425_create_curriculums.rb
@@ -1,0 +1,10 @@
+class CreateCurriculums < ActiveRecord::Migration[8.0]
+  def change
+    create_table :curriculums do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :schedule_item_code
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_23_201510) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_28_182425) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -47,6 +47,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_201510) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "curriculums", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "schedule_item_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_curriculums_on_user_id"
   end
 
   create_table "event_contents", force: :cascade do |t|
@@ -112,6 +120,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_201510) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "curriculums", "users"
   add_foreign_key "event_contents", "users"
   add_foreign_key "event_task_contents", "event_contents"
   add_foreign_key "event_task_contents", "event_tasks"

--- a/spec/factories/curriculums.rb
+++ b/spec/factories/curriculums.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :curriculum do
+    user
+    schedule_item_code { SecureRandom.alphanumeric(8) }
+  end
+end

--- a/spec/models/curriculum_spec.rb
+++ b/spec/models/curriculum_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Curriculum, type: :model do
+end

--- a/spec/system/curriculum/user_register_a_curriculum_spec.rb
+++ b/spec/system/curriculum/user_register_a_curriculum_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'A curriculum is generated for user schedule item', type: :system do
+  it 'and user must be authenticated' do
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+
+    visit schedule_item_path(schedule_item)
+
+    expect(current_path).to eq new_user_session_path
+    expect(Curriculum.count).to eq 0
+  end
+
+  it 'when access your schedule item page for the first time' do
+    user = create(:user, id: 99)
+    event =  [ build(:event, name: 'Ruby on Rails', description: 'Introdução ao Rails com TDD',
+                  start_date: 7.days.from_now, end_date: 14.days.from_now, url: 'www.meuevento.com/eventos/Ruby-on-Rails',
+                  event_type: 'Presencial', location: 'Juiz de Fora', participant_limit: 100, status: 'Publicado') ]
+    schedule_items = [ build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD') ]
+
+    allow(Event).to receive(:all).and_return(event)
+    allow(Event).to receive(:find).and_return(event.first)
+    allow(event.first).to receive(:schedule_items).and_return(schedule_items)
+    allow(ScheduleItem).to receive(:find).and_return(schedule_items.first)
+
+    login_as user, scope: :user
+    visit root_path
+    click_on 'Ruby on Rails'
+    click_on 'TDD com Rails'
+
+    curriculum = Curriculum.find_by(schedule_item_code: '99', user_id: 99)
+    expect(curriculum.schedule_item_code).to eq '99'
+    expect(curriculum.user_id). to eq 99
+  end
+
+  it 'and should not create curriculum when schedule item does not exist' do
+    user = create(:user)
+
+    login_as user, scope: :user
+    visit schedule_item_path(9999)
+
+    expect(current_path).to eq events_path
+    expect(Curriculum.count).to eq 0
+  end
+end


### PR DESCRIPTION
Essa implementação é responsavel pela criação do modelo de Curriculo que serve como vinculo entre item da agenda (programação do evento) e o usuário, a partir dela vamos conseguir posteriormente criar e vincular tarefas e conteúdos à um item de agenda especifico.

Foi criado uma verificação no controller que ao acessar a página do item da agenda pela primeira vez, o curriculo é gerado automaticamente

Resolve #70 