### PR TITLE
Fix/75 Adição de campos ao perfil, Adição de privacidade na visualização de perfil e melhorias visuais.

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -27,7 +27,7 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:profile).permit(:title, :about_me, :profile_picture)
+    params.require(:profile).permit(:title, :about_me, :profile_picture, :pronoun, :city, :birth, :gender)
   end
 
   def check_if_have_an_existing_profile

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,6 +14,8 @@ class ProfilesController < ApplicationController
 
   def create
     @profile = current_user.build_profile(profile_params)
+    @profile.pronoun = params[:profile][:other_pronoun] if params[:profile][:other_pronoun] && profile_params[:pronouns] == 'Outro:'
+    @profile.gender = params[:profile][:other_gender] if params[:profile][:other_gender] && profile_params[:gender] == 'Outro:'
     create_networks(params[:profile][:social_networks])
 
     if @profile.save

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -43,7 +43,8 @@ class ProfilesController < ApplicationController
   end
 
   def profile_params
-    filtered_params = params.require(:profile).permit(:title, :about_me, :profile_picture, :pronoun, :city, :birth, :gender)
+    filtered_params = params.require(:profile).permit(:title, :about_me, :profile_picture, :pronoun, :city, :birth,
+                                                      :gender, :display_birth, :display_city, :display_gender, :display_pronoun)
     filtered_params[:pronoun] = params[:profile][:other_pronoun] if filtered_params[:pronoun] == t('profiles.pronoun_options.other')
     filtered_params[:gender] = params[:profile][:other_gender] if filtered_params[:gender] == t('profiles.gender_options.other')
     filtered_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,17 +10,19 @@ class ProfilesController < ApplicationController
   end
   def new
     @profile = current_user.build_profile
+    @pronoun_list = pronoun_options
+    @gender_list = gender_options
   end
 
   def create
     @profile = current_user.build_profile(profile_params)
-    @profile.pronoun = params[:profile][:other_pronoun] if params[:profile][:other_pronoun] && profile_params[:pronouns] == 'Outro:'
-    @profile.gender = params[:profile][:other_gender] if params[:profile][:other_gender] && profile_params[:gender] == 'Outro:'
     create_networks(params[:profile][:social_networks])
 
     if @profile.save
       redirect_to events_path, notice: t('profiles.create.success')
     else
+      @pronoun_list = pronoun_options
+      @gender_list = gender_options
       flash.now[:alert] = t('profiles.create.error')
       render :new, status: :unprocessable_entity
     end
@@ -28,8 +30,23 @@ class ProfilesController < ApplicationController
 
   private
 
+  def pronoun_options
+    [ t('profiles.pronoun_options.she_her'), t('profiles.pronoun_options.he_him'),
+      t('profiles.pronoun_options.they_them'), t('profiles.pronoun_options.prefer_not_inform'),
+      t('profiles.pronoun_options.other') ]
+  end
+
+  def gender_options
+    [ t('profiles.gender_options.male'), t('profiles.gender_options.female'),
+      t('profiles.gender_options.not_binary'), t('profiles.gender_options.prefer_not_answer'),
+      t('profiles.gender_options.other') ]
+  end
+
   def profile_params
-    params.require(:profile).permit(:title, :about_me, :profile_picture, :pronoun, :city, :birth, :gender)
+    filtered_params = params.require(:profile).permit(:title, :about_me, :profile_picture, :pronoun, :city, :birth, :gender)
+    filtered_params[:pronoun] = params[:profile][:other_pronoun] if filtered_params[:pronoun] == t('profiles.pronoun_options.other')
+    filtered_params[:gender] = params[:profile][:other_gender] if filtered_params[:gender] == t('profiles.gender_options.other')
+    filtered_params
   end
 
   def check_if_have_an_existing_profile

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,7 +2,7 @@ class Profile < ApplicationRecord
   belongs_to :user
   has_one_attached :profile_picture
   has_many :social_networks
-  validates :title, :about_me, :profile_picture, presence: true
+  validates :title, :about_me, :profile_picture, :city, :gender, :pronoun, :birth, presence: true
   validates :username, uniqueness: true
   before_create :generate_unique_username
 

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -24,16 +24,22 @@
     <%= f.select :pronoun, @pronoun_list, { include_blank: "" } %>
     <%= f.label :other_pronoun, class: 'label-primary'  %>
     <%= f.text_field :other_pronoun, class: 'field-primary' %>
+    <%= f.label :display_pronoun, class: 'label-primary'  %>
+    <%= f.check_box :display_pronoun %>
   </div>
 
   <div class="field">
     <%= f.label :city, class: 'label-primary'  %>
     <%= f.text_area :city, class: 'text-area' %>
+    <%= f.label :display_city, class: 'label-primary'  %>
+    <%= f.check_box :display_city %>
   </div>
 
   <div class="field">
     <%= f.label :birth, class: 'label-primary'  %>
     <%= f.date_field :birth %>
+    <%= f.label :display_birth, class: 'label-primary'  %>
+    <%= f.check_box :display_birth %>
   </div>
 
   <div class="field">
@@ -41,6 +47,8 @@
     <%= f.select :gender, @gender_list, { include_blank: "" } %>    
     <%= f.label :other_gender, class: 'label-primary'  %>
     <%= f.text_field :other_gender, class: 'field-primary' %>
+    <%= f.label :display_gender, class: 'label-primary' %>
+    <%= f.check_box :display_gender %>
   </div>
 
   <div class="my-3">

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -19,36 +19,44 @@
     <%= f.text_area :about_me, class: 'text-area' %>
   </div>
 
-  <div class="field">
+  <div class="field border-2 border-black p-4">
     <%= f.label :pronoun, class: 'label-primary'  %>
-    <%= f.select :pronoun, @pronoun_list, { include_blank: "" } %>
+    <%= f.select :pronoun, @pronoun_list, { include_blank: "" }, class: 'field-primary border border-gray' %>
     <%= f.label :other_pronoun, class: 'label-primary'  %>
     <%= f.text_field :other_pronoun, class: 'field-primary' %>
-    <%= f.label :display_pronoun, class: 'label-primary'  %>
-    <%= f.check_box :display_pronoun %>
+    <div class="flex my-6 items-center">
+      <%= f.check_box :display_pronoun, class: 'mr-4' %>
+      <%= f.label :display_pronoun %>
+    </div>
   </div>
 
   <div class="field">
     <%= f.label :city, class: 'label-primary'  %>
     <%= f.text_area :city, class: 'text-area' %>
-    <%= f.label :display_city, class: 'label-primary'  %>
-    <%= f.check_box :display_city %>
+    <div class="flex my-6 items-center">
+      <%= f.check_box :display_city, class: 'mr-4' %>
+      <%= f.label :display_city %>
+    </div>
   </div>
 
-  <div class="field">
+  <div class="">
     <%= f.label :birth, class: 'label-primary'  %>
-    <%= f.date_field :birth %>
-    <%= f.label :display_birth, class: 'label-primary'  %>
-    <%= f.check_box :display_birth %>
+    <%= f.date_field :birth, class: 'field-primary border mt-3'  %>
+    <div class="flex my-6 items-center">
+      <%= f.check_box :display_birth, class: 'mr-4' %>
+      <%= f.label :display_birth  %>
+    </div>
   </div>
 
-  <div class="field">
+  <div class="field  border-2 border-black p-4">
     <%= f.label :gender, class: 'label-primary'  %>
-    <%= f.select :gender, @gender_list, { include_blank: "" } %>    
+    <%= f.select :gender, @gender_list, { include_blank: "" }, class: 'field-primary border border-gray' %>    
     <%= f.label :other_gender, class: 'label-primary'  %>
     <%= f.text_field :other_gender, class: 'field-primary' %>
-    <%= f.label :display_gender, class: 'label-primary' %>
-    <%= f.check_box :display_gender %>
+    <div class="flex my-6 items-center">
+      <%= f.check_box :display_gender, class: 'mr-4' %>
+      <%= f.label :display_gender %>
+    </div>
   </div>
 
   <div class="my-3">

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -21,7 +21,7 @@
 
   <div class="field">
     <%= f.label :pronoun, class: 'label-primary'  %>
-    <%= f.select :pronoun, options_for_select(['Ela/Dela','Ele/Dele', 'Elu/Delu', 'Prefiro não informar', 'Outro:']) %>
+    <%= f.select :pronoun, @pronoun_list, { include_blank: "" } %>
     <%= f.label :other_pronoun, class: 'label-primary'  %>
     <%= f.text_field :other_pronoun, class: 'field-primary' %>
   </div>
@@ -38,7 +38,7 @@
 
   <div class="field">
     <%= f.label :gender, class: 'label-primary'  %>
-    <%= f.select :gender, options_for_select(['Masculino','Feminino', 'Não-binário', 'Prefiro não responder', 'Outro:'])%>    
+    <%= f.select :gender, @gender_list, { include_blank: "" } %>    
     <%= f.label :other_gender, class: 'label-primary'  %>
     <%= f.text_field :other_gender, class: 'field-primary' %>
   </div>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -21,7 +21,9 @@
 
   <div class="field">
     <%= f.label :pronoun, class: 'label-primary'  %>
-    <%= f.text_area :pronoun, class: 'text-area' %>
+    <%= f.select :pronoun, options_for_select(['Ela/Dela','Ele/Dele', 'Elu/Delu', 'Prefiro não informar', 'Outro:']) %>
+    <%= f.label :other_pronoun, class: 'label-primary'  %>
+    <%= f.text_field :other_pronoun, class: 'field-primary' %>
   </div>
 
   <div class="field">
@@ -36,7 +38,9 @@
 
   <div class="field">
     <%= f.label :gender, class: 'label-primary'  %>
-    <%= f.text_area :gender, class: 'text-area'%>
+    <%= f.select :gender, options_for_select(['Masculino','Feminino', 'Não-binário', 'Prefiro não responder', 'Outro:'])%>    
+    <%= f.label :other_gender, class: 'label-primary'  %>
+    <%= f.text_field :other_gender, class: 'field-primary' %>
   </div>
 
   <div class="my-3">

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -19,6 +19,26 @@
     <%= f.text_area :about_me, class: 'text-area' %>
   </div>
 
+  <div class="field">
+    <%= f.label :pronoun, class: 'label-primary'  %>
+    <%= f.text_area :pronoun, class: 'text-area' %>
+  </div>
+
+  <div class="field">
+    <%= f.label :city, class: 'label-primary'  %>
+    <%= f.text_area :city, class: 'text-area' %>
+  </div>
+
+  <div class="field">
+    <%= f.label :birth, class: 'label-primary'  %>
+    <%= f.date_field :birth %>
+  </div>
+
+  <div class="field">
+    <%= f.label :gender, class: 'label-primary'  %>
+    <%= f.text_area :gender, class: 'text-area'%>
+  </div>
+
   <div class="my-3">
     <%= f.label :profile_picture %>
     <%= f.file_field :profile_picture %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -26,7 +26,7 @@
             <h3 class="text-xl font-bold"><%= t('.gender') %></h3>
             <p class="mt-7"><%= @profile.gender %></p>
             <h3 class="text-xl font-bold"><%= t('.birth') %></h3>
-            <p class="mt-7"><%= @profile.birth.strftime('%d/%m/%Y') %></p>
+            <p class="mt-7"><%= @profile.birth&.strftime('%d/%m/%Y') %></p>
             <h3 class="text-xl font-bold"><%= t('.city') %></h3>
             <p class="mt-7"><%= @profile.city %></p>
         </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -21,14 +21,22 @@
         <div>
             <h3 class="text-xl font-bold"><%= t('.about_me') %></h3>
             <p class="mt-7"><%= @profile.about_me %></p>
-            <h3 class="text-xl font-bold"><%= t('.pronoun') %></h3>
-            <p class="mt-7"><%= @profile.pronoun %></p>
-            <h3 class="text-xl font-bold"><%= t('.gender') %></h3>
-            <p class="mt-7"><%= @profile.gender %></p>
-            <h3 class="text-xl font-bold"><%= t('.birth') %></h3>
-            <p class="mt-7"><%= @profile.birth&.strftime('%d/%m/%Y') %></p>
-            <h3 class="text-xl font-bold"><%= t('.city') %></h3>
-            <p class="mt-7"><%= @profile.city %></p>
+            <% if @profile.display_pronoun %>
+                <h3 class="text-xl font-bold"><%= t('.pronoun') %></h3>
+                <p class="mt-7"><%= @profile.pronoun %></p>
+            <% end %>
+            <% if @profile.display_gender %>
+                <h3 class="text-xl font-bold"><%= t('.gender') %></h3>
+                <p class="mt-7"><%= @profile.gender %></p>
+            <% end %>
+            <% if @profile.display_birth %>
+                <h3 class="text-xl font-bold"><%= t('.birth') %></h3>
+                <p class="mt-7"><%= @profile.birth&.strftime('%d/%m/%Y') %></p>
+            <% end %>
+            <% if @profile.display_city %>
+                <h3 class="text-xl font-bold"><%= t('.city') %></h3>
+                <p class="mt-7"><%= @profile.city %></p>
+            <% end %>
         </div>
     </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,11 +1,10 @@
 <section>
-    <h2 class="heading-2"><%= t('.title') %></h2>
-
     <div>
         <div class="mt-10 flex items-center justify-start">
             <div class="w-2/3">
-                <p class="tracking-wider text-blue-600 text-2xl"><%= @profile.title %></p>
-                <h3 class="font-bold text-2xl"><%= @profile.user.full_name %></h3>
+                <h2 class="heading-2"><%= @profile.user.full_name %></h2>
+                <p class="tracking-wider text-2xl"><%= @profile.title %></p>
+                <h3 class="font-bold text-2xl"></h3>
                 <div class="nav_social_network_container">
                     <% @profile.social_networks.each do |network| %>
                             <%= link_to(network.url, class: 'container_link', target: "_blank") do %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -21,6 +21,14 @@
         <div>
             <h3 class="text-xl font-bold"><%= t('.about_me') %></h3>
             <p class="mt-7"><%= @profile.about_me %></p>
+            <h3 class="text-xl font-bold"><%= t('.pronoun') %></h3>
+            <p class="mt-7"><%= @profile.pronoun %></p>
+            <h3 class="text-xl font-bold"><%= t('.gender') %></h3>
+            <p class="mt-7"><%= @profile.gender %></p>
+            <h3 class="text-xl font-bold"><%= t('.birth') %></h3>
+            <p class="mt-7"><%= @profile.birth.strftime('%d/%m/%Y') %></p>
+            <h3 class="text-xl font-bold"><%= t('.city') %></h3>
+            <p class="mt-7"><%= @profile.city %></p>
         </div>
     </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,20 +22,20 @@
             <h3 class="text-xl font-bold"><%= t('.about_me') %></h3>
             <p class="mt-7"><%= @profile.about_me %></p>
             <% if @profile.display_pronoun %>
-                <h3 class="text-xl font-bold"><%= t('.pronoun') %></h3>
-                <p class="mt-7"><%= @profile.pronoun %></p>
+                <h3 class="text-xl font-bold mt-4"><%= t('.pronoun') %></h3>
+                <p class="my-2"><%= @profile.pronoun %></p>
             <% end %>
             <% if @profile.display_gender %>
                 <h3 class="text-xl font-bold"><%= t('.gender') %></h3>
-                <p class="mt-7"><%= @profile.gender %></p>
+                <p class="my-2"><%= @profile.gender %></p>
             <% end %>
             <% if @profile.display_birth %>
                 <h3 class="text-xl font-bold"><%= t('.birth') %></h3>
-                <p class="mt-7"><%= @profile.birth&.strftime('%d/%m/%Y') %></p>
+                <p class="my-2"><%= @profile.birth&.strftime('%d/%m/%Y') %></p>
             <% end %>
             <% if @profile.display_city %>
                 <h3 class="text-xl font-bold"><%= t('.city') %></h3>
-                <p class="mt-7"><%= @profile.city %></p>
+                <p class="my-2"><%= @profile.city %></p>
             <% end %>
         </div>
     </div>

--- a/config/locales/controller.pt-BR.yml
+++ b/config/locales/controller.pt-BR.yml
@@ -6,3 +6,15 @@ pt-BR:
       success: 'Perfil cadastrado com sucesso.'
       error: 'Falha ao registrar o perfil.'
     check_if_have_an_existing_profile: 'Só é possível cadastrar um perfil.'
+    pronoun_options:
+      he_him: 'Ele/Dele'
+      she_her: 'Ela/Dela'
+      they_them: 'Elu/Delu'
+      prefer_not_inform: 'Prefiro não informar'
+      other: 'Outro'
+    gender_options:
+      male: 'Masculino'
+      female: 'Feminino'
+      not_binary: 'Não-binário'
+      prefer_not_answer: 'Prefiro não responder'
+      other: 'Outro'

--- a/config/locales/model/profile.pt-BR.yml
+++ b/config/locales/model/profile.pt-BR.yml
@@ -16,3 +16,7 @@ pt-BR:
         birth: 'Data de Nascimento'
         gender: 'Gênero'
         other_gender: 'Outro Gênero'
+        display_pronoun: 'Exibir Pronome'
+        display_gender: 'Exibir Gênero'
+        display_city: 'Exibir Cidade'
+        display_birth: 'Exibir Data de Nascimento'

--- a/config/locales/model/profile.pt-BR.yml
+++ b/config/locales/model/profile.pt-BR.yml
@@ -11,6 +11,8 @@ pt-BR:
         github: 'GitHub'
         social_networks: 'Rede Social'
         pronoun: 'Pronome'
+        other_pronoun: 'Outro Pronome'
         city: 'Cidade'
         birth: 'Data de Nascimento'
         gender: 'Gênero'
+        other_gender: 'Outro Gênero'

--- a/config/locales/model/profile.pt-BR.yml
+++ b/config/locales/model/profile.pt-BR.yml
@@ -9,4 +9,8 @@ pt-BR:
         profile_picture: 'Foto de Perfil'
         my_site: 'Meu site'
         github: 'GitHub'
-        social_networks: Rede Social
+        social_networks: 'Rede Social'
+        pronoun: 'Pronome'
+        city: 'Cidade'
+        birth: 'Data de Nascimento'
+        gender: 'Gênero'

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -40,6 +40,8 @@ pt-BR:
       dont_exist_event: 'Não existe nenhum evento ao qual você faça parte. Se você acha que isso é um erro, entre em contato com algum organizador.'
       gender: 'Gênero'
       pronoun: 'Pronomes'
+      birth: 'Data de Nascimento'
+      city: 'Cidade'
   events: 
     show:
       schedule_items_title: 'Suas Agendas'

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -38,6 +38,8 @@ pt-BR:
       my_events: 'Meus Eventos'
       about_me: 'Sobre mim'
       dont_exist_event: 'Não existe nenhum evento ao qual você faça parte. Se você acha que isso é um erro, entre em contato com algum organizador.'
+      gender: 'Gênero'
+      pronoun: 'Pronomes'
   events: 
     show:
       schedule_items_title: 'Suas Agendas'

--- a/db/migrate/20250128183657_add_pronoun_gender_city_birth_to_profile.rb
+++ b/db/migrate/20250128183657_add_pronoun_gender_city_birth_to_profile.rb
@@ -1,0 +1,8 @@
+class AddPronounGenderCityBirthToProfile < ActiveRecord::Migration[8.0]
+  def change
+    add_column :profiles, :pronoun, :string
+    add_column :profiles, :gender, :string
+    add_column :profiles, :city, :string
+    add_column :profiles, :birth, :date
+  end
+end

--- a/db/migrate/20250129181819_add_gender_pronoun_city_and_birth_private_in_profile.rb
+++ b/db/migrate/20250129181819_add_gender_pronoun_city_and_birth_private_in_profile.rb
@@ -1,0 +1,8 @@
+class AddGenderPronounCityAndBirthPrivateInProfile < ActiveRecord::Migration[8.0]
+  def change
+    add_column :profiles, :gender_private, :boolean, default: true
+    add_column :profiles, :pronoun_private, :boolean, default: true
+    add_column :profiles, :city_private, :boolean, default: true
+    add_column :profiles, :birth_private, :boolean, default: true
+  end
+end

--- a/db/migrate/20250129184519_rename_column_in_profiles.rb
+++ b/db/migrate/20250129184519_rename_column_in_profiles.rb
@@ -1,0 +1,8 @@
+class RenameColumnInProfiles < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :profiles, :gender_private, :display_gender
+    rename_column :profiles, :pronoun_private, :display_pronoun
+    rename_column :profiles, :city_private, :display_city
+    rename_column :profiles, :birth_private, :display_birth
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_28_183657) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_29_184519) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -87,6 +87,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_28_183657) do
     t.string "gender"
     t.string "city"
     t.date "birth"
+    t.boolean "display_gender", default: true
+    t.boolean "display_pronoun", default: true
+    t.boolean "display_city", default: true
+    t.boolean "display_birth", default: true
     t.index ["user_id"], name: "index_profiles_on_user_id"
     t.index ["username"], name: "index_profiles_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_23_201510) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_28_183657) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -83,6 +83,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_201510) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username"
+    t.string "pronoun"
+    t.string "gender"
+    t.string "city"
+    t.date "birth"
     t.index ["user_id"], name: "index_profiles_on_user_id"
     t.index ["username"], name: "index_profiles_on_username", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 #   end
 User.skip_callback(:create, :before, :api_auth_user)
 user = User.create!(first_name: 'João', last_name: 'Campus', email: 'joao@email.com', password: '123456')
-user_2 = User.create!(first_name: 'João', last_name: 'Campus', email: 'speaker0@email.com', password: '123456')
+User.create!(first_name: 'João', last_name: 'Campus', email: 'speaker0@email.com', password: '123456')
 User.set_callback(:create, :before, :api_auth_user)
 
 profile = Profile.create!(title: 'Instrutor / Desenvolvedor',
@@ -23,9 +23,8 @@ profile = Profile.create!(title: 'Instrutor / Desenvolvedor',
                           Minha motivação vem da possibilidade de resolver problemas reais, criando sistemas que otimizem processos,
                           melhorem a experiência dos usuários e tragam impacto positivo para as empresas. Fora do mundo do código, gosto
                             de compartilhar conhecimento, aprender com a comunidade e me desafiar constantemente a ser um profissional melhor.',
-                          user: user, profile_picture: { io: File.open(Rails.root.join('spec/fixtures/puts.png')),
-                                                         filename: 'puts.png',
-                                                         content_type: 'image/png' })
+                          user: user, profile_picture: { io: File.open(Rails.root.join('spec/fixtures/puts.png')), filename: 'puts.png',
+                          content_type: 'image/png' }, gender: 'Masculino', pronoun: 'Ele/Dele', city: 'Salvador', birth: '1999-01-25')
 profile.social_networks.create(url: 'https://www.joaotutoriais.com/', social_network_type: :my_site)
 profile.social_networks.create(url: 'https://www.youtube.com/@JoãoTutoriais', social_network_type: :youtube)
 profile.social_networks.create(url: 'https://x.com/joao', social_network_type: :x)

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     title { "Instrutor" }
     about_me { "Minha vida pessoal" }
     user
+    city { "Florianópolis" }
+    pronoun { "Ele/Dele" }
+    gender { "Masculino" }
+    birth { "2000-01-01" }
     profile_picture { Rack::Test::UploadedFile.new('spec/fixtures/puts.png', 'image/png') }
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Profile, type: :model do
     subject { create(:profile) }
     it { validate_presence_of(:title) }
     it { should validate_presence_of(:about_me) }
+    it { should validate_presence_of(:pronoun) }
+    it { should validate_presence_of(:gender) }
+    it { should validate_presence_of(:birth) }
+    it { should validate_presence_of(:city) }
     it { should have_one_attached(:profile_picture) }
     it { should belong_to(:user) }
     it { should have_many(:social_networks) }

--- a/spec/system/profile/user_register_a_profile_spec.rb
+++ b/spec/system/profile/user_register_a_profile_spec.rb
@@ -22,10 +22,11 @@ describe 'User register a profile' do
     click_on 'Cadastrar'
     fill_in 'Título', with: 'Instrutor / Desenvolvedor'
     fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
-    fill_in 'Pronome', with: 'Ele / Dele'
+    select('Ele/Dele', from: 'Pronome')
     fill_in 'Cidade', with: 'Florianópolis'
     fill_in 'Data de Nascimento', with: '1999-01-25'
-    fill_in 'Gênero', with: 'Masculino'
+    select('Outro:', from: 'Gênero')
+    fill_in 'Outro Gênero', with: 'Transgênero'
     attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
     fill_in 'Meu site', with: 'https://www.joaotutoriais.com/'
     fill_in 'Youtube', with: 'https://www.youtube.com/@JoãoTutoriais'
@@ -40,10 +41,10 @@ describe 'User register a profile' do
     expect(page).to have_content('Perfil cadastrado com sucesso.')
     expect(profile_test.title).to eq('Instrutor / Desenvolvedor')
     expect(profile_test.about_me).to eq('Sou João, desenvolvedor Ruby com foco em Ruby on Rails.')
-    expect(profile_test.pronoun).to eq('Ele / Dele')
+    expect(profile_test.pronoun).to eq('Ele/Dele')
     expect(profile_test.city).to eq('Florianópolis')
     expect(profile_test.birth.strftime('%d/%m/%Y')).to eq('25/01/1999')
-    expect(profile_test.gender).to eq('Masculino')
+    expect(profile_test.gender).to eq('Transgênero')
     expect(profile_test.profile_picture.attached?).to eq(true)
     expect(networks.length).to eq(5)
     expect(networks.find_by(url: 'https://www.youtube.com/@JoãoTutoriais').present?).to eq(true)

--- a/spec/system/profile/user_register_a_profile_spec.rb
+++ b/spec/system/profile/user_register_a_profile_spec.rb
@@ -25,8 +25,7 @@ describe 'User register a profile' do
     select('Ele/Dele', from: 'Pronome')
     fill_in 'Cidade', with: 'Florianópolis'
     fill_in 'Data de Nascimento', with: '1999-01-25'
-    select('Outro:', from: 'Gênero')
-    fill_in 'Outro Gênero', with: 'Transgênero'
+    select('Masculino', from: 'Gênero')
     attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
     fill_in 'Meu site', with: 'https://www.joaotutoriais.com/'
     fill_in 'Youtube', with: 'https://www.youtube.com/@JoãoTutoriais'
@@ -44,7 +43,7 @@ describe 'User register a profile' do
     expect(profile_test.pronoun).to eq('Ele/Dele')
     expect(profile_test.city).to eq('Florianópolis')
     expect(profile_test.birth.strftime('%d/%m/%Y')).to eq('25/01/1999')
-    expect(profile_test.gender).to eq('Transgênero')
+    expect(profile_test.gender).to eq('Masculino')
     expect(profile_test.profile_picture.attached?).to eq(true)
     expect(networks.length).to eq(5)
     expect(networks.find_by(url: 'https://www.youtube.com/@JoãoTutoriais').present?).to eq(true)
@@ -52,6 +51,41 @@ describe 'User register a profile' do
     expect(networks.find_by(url: 'https://x.com/joao').present?).to eq(true)
     expect(networks.find_by(url: 'https://github.com/joaorsalmeida').present?).to eq(true)
     expect(networks.find_by(url: 'https://www.facebook.com/joaoalmeida').present?).to eq(true)
+  end
+
+  it 'with other gender and pronoun' do
+    service = ExternalEventApi::UserFindEmailService
+    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+
+    visit root_path
+    click_on 'Criar conta'
+    fill_in 'E-mail', with: 'joao@campuscode.com'
+    fill_in 'Senha', with: 'password'
+    fill_in 'Confirme sua senha', with: 'password'
+    fill_in 'Nome', with: 'João'
+    fill_in 'Sobrenome', with: 'Almeida'
+    click_on 'Cadastrar'
+    fill_in 'Título', with: 'Instrutor / Desenvolvedor'
+    fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
+    select('Outro', from: 'Pronome')
+    fill_in 'Outro Pronome', with: 'Ellu / Dellu'
+    fill_in 'Cidade', with: 'Florianópolis'
+    fill_in 'Data de Nascimento', with: '1999-01-25'
+    select('Outro', from: 'Gênero')
+    fill_in 'Outro Gênero', with: 'Transgênero'
+    attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
+    click_on 'Criar perfil'
+
+    profile_test = Profile.first
+    expect(current_path).to eq(events_path)
+    expect(page).to have_content('Perfil cadastrado com sucesso.')
+    expect(profile_test.title).to eq('Instrutor / Desenvolvedor')
+    expect(profile_test.about_me).to eq('Sou João, desenvolvedor Ruby com foco em Ruby on Rails.')
+    expect(profile_test.pronoun).to eq('Ellu / Dellu')
+    expect(profile_test.city).to eq('Florianópolis')
+    expect(profile_test.birth.strftime('%d/%m/%Y')).to eq('25/01/1999')
+    expect(profile_test.gender).to eq('Transgênero')
+    expect(profile_test.profile_picture.attached?).to eq(true)
   end
 
   it 'with blank fields' do
@@ -68,6 +102,8 @@ describe 'User register a profile' do
     click_on 'Cadastrar'
     fill_in 'Título', with: ''
     fill_in 'Sobre mim', with: ''
+    fill_in 'Cidade', with: ''
+    fill_in 'Data de Nascimento', with: ''
     click_on 'Criar perfil'
 
     expect(current_path).to eq(profiles_path)
@@ -75,6 +111,34 @@ describe 'User register a profile' do
     expect(page).to have_content('Título não pode ficar em branco')
     expect(page).to have_content('Sobre mim não pode ficar em branco')
     expect(page).to have_content('Foto de Perfil não pode ficar em branco')
+    expect(page).to have_content('Data de Nascimento não pode ficar em branco')
+    expect(page).to have_content('Gênero não pode ficar em branco')
+    expect(page).to have_content('Pronome não pode ficar em branco')
+    expect(page).to have_content('Cidade não pode ficar em branco')
+  end
+
+  it 'with blank fields for gender and pronoun' do
+    service = ExternalEventApi::UserFindEmailService
+    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+
+    visit root_path
+    click_on 'Criar conta'
+    fill_in 'E-mail', with: 'joao@campuscode.com'
+    fill_in 'Senha', with: 'password'
+    fill_in 'Confirme sua senha', with: 'password'
+    fill_in 'Nome', with: 'João'
+    fill_in 'Sobrenome', with: 'Almeida'
+    click_on 'Cadastrar'
+    select('Outro', from: 'Pronome')
+    fill_in 'Outro Pronome', with: ''
+    select('Outro', from: 'Gênero')
+    fill_in 'Outro Gênero', with: ''
+    click_on 'Criar perfil'
+
+    expect(current_path).to eq(profiles_path)
+    expect(page).to have_content('Falha ao registrar o perfil.')
+    expect(page).to have_content('Gênero não pode ficar em branco')
+    expect(page).to have_content('Pronome não pode ficar em branco')
   end
 
   it 'with invalid network' do
@@ -131,5 +195,50 @@ describe 'User register a profile' do
     expect(current_path).to eq(new_profile_path)
     expect(page).not_to have_content('Meu Perfil')
     expect(page).to have_content('Cadastre seu perfil')
+  end
+
+  it 'and select public and private fields' do
+    service = ExternalEventApi::UserFindEmailService
+    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+
+    visit root_path
+    click_on 'Criar conta'
+    fill_in 'E-mail', with: 'joao@campuscode.com'
+    fill_in 'Senha', with: 'password'
+    fill_in 'Confirme sua senha', with: 'password'
+    fill_in 'Nome', with: 'João'
+    fill_in 'Sobrenome', with: 'Almeida'
+    click_on 'Cadastrar'
+    fill_in 'Título', with: 'Instrutor / Desenvolvedor'
+    fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
+    select('Ele/Dele', from: 'Pronome')
+    fill_in 'Cidade', with: 'Florianópolis'
+    fill_in 'Data de Nascimento', with: '1999-01-25'
+    select('Masculino', from: 'Gênero')
+    attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
+    fill_in 'Meu site', with: 'https://www.joaotutoriais.com/'
+    fill_in 'Youtube', with: 'https://www.youtube.com/@JoãoTutoriais'
+    fill_in 'Twitter', with: 'https://x.com/joao'
+    fill_in 'GitHub', with: 'https://github.com/joaorsalmeida'
+    fill_in 'Facebook', with: 'https://www.facebook.com/joaoalmeida'
+    click_on 'Criar perfil'
+
+    profile_test = Profile.first
+    networks = profile_test.social_networks
+    expect(current_path).to eq(events_path)
+    expect(page).to have_content('Perfil cadastrado com sucesso.')
+    expect(profile_test.title).to eq('Instrutor / Desenvolvedor')
+    expect(profile_test.about_me).to eq('Sou João, desenvolvedor Ruby com foco em Ruby on Rails.')
+    expect(profile_test.pronoun).to eq('Ele/Dele')
+    expect(profile_test.city).to eq('Florianópolis')
+    expect(profile_test.birth.strftime('%d/%m/%Y')).to eq('25/01/1999')
+    expect(profile_test.gender).to eq('Masculino')
+    expect(profile_test.profile_picture.attached?).to eq(true)
+    expect(networks.length).to eq(5)
+    expect(networks.find_by(url: 'https://www.youtube.com/@JoãoTutoriais').present?).to eq(true)
+    expect(networks.find_by(url: 'https://www.joaotutoriais.com/').present?).to eq(true)
+    expect(networks.find_by(url: 'https://x.com/joao').present?).to eq(true)
+    expect(networks.find_by(url: 'https://github.com/joaorsalmeida').present?).to eq(true)
+    expect(networks.find_by(url: 'https://www.facebook.com/joaoalmeida').present?).to eq(true)
   end
 end

--- a/spec/system/profile/user_register_a_profile_spec.rb
+++ b/spec/system/profile/user_register_a_profile_spec.rb
@@ -22,6 +22,10 @@ describe 'User register a profile' do
     click_on 'Cadastrar'
     fill_in 'Título', with: 'Instrutor / Desenvolvedor'
     fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
+    fill_in 'Pronome', with: 'Ele / Dele'
+    fill_in 'Cidade', with: 'Florianópolis'
+    fill_in 'Data de Nascimento', with: '1999-01-25'
+    fill_in 'Gênero', with: 'Masculino'
     attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
     fill_in 'Meu site', with: 'https://www.joaotutoriais.com/'
     fill_in 'Youtube', with: 'https://www.youtube.com/@JoãoTutoriais'
@@ -36,6 +40,10 @@ describe 'User register a profile' do
     expect(page).to have_content('Perfil cadastrado com sucesso.')
     expect(profile_test.title).to eq('Instrutor / Desenvolvedor')
     expect(profile_test.about_me).to eq('Sou João, desenvolvedor Ruby com foco em Ruby on Rails.')
+    expect(profile_test.pronoun).to eq('Ele / Dele')
+    expect(profile_test.city).to eq('Florianópolis')
+    expect(profile_test.birth.strftime('%d/%m/%Y')).to eq('25/01/1999')
+    expect(profile_test.gender).to eq('Masculino')
     expect(profile_test.profile_picture.attached?).to eq(true)
     expect(networks.length).to eq(5)
     expect(networks.find_by(url: 'https://www.youtube.com/@JoãoTutoriais').present?).to eq(true)

--- a/spec/system/profile/user_register_a_profile_spec.rb
+++ b/spec/system/profile/user_register_a_profile_spec.rb
@@ -54,17 +54,11 @@ describe 'User register a profile' do
   end
 
   it 'with other gender and pronoun' do
-    service = ExternalEventApi::UserFindEmailService
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+    user = create(:user, first_name: 'João')
 
-    visit root_path
-    click_on 'Criar conta'
-    fill_in 'E-mail', with: 'joao@campuscode.com'
-    fill_in 'Senha', with: 'password'
-    fill_in 'Confirme sua senha', with: 'password'
-    fill_in 'Nome', with: 'João'
-    fill_in 'Sobrenome', with: 'Almeida'
-    click_on 'Cadastrar'
+    login_as user
+    visit events_path
+    click_on 'Cadastrar Perfil'
     fill_in 'Título', with: 'Instrutor / Desenvolvedor'
     fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
     select('Outro', from: 'Pronome')
@@ -89,17 +83,11 @@ describe 'User register a profile' do
   end
 
   it 'with blank fields' do
-    service = ExternalEventApi::UserFindEmailService
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+    user = create(:user, first_name: 'João')
 
-    visit root_path
-    click_on 'Criar conta'
-    fill_in 'E-mail', with: 'joao@campuscode.com'
-    fill_in 'Senha', with: 'password'
-    fill_in 'Confirme sua senha', with: 'password'
-    fill_in 'Nome', with: 'João'
-    fill_in 'Sobrenome', with: 'Almeida'
-    click_on 'Cadastrar'
+    login_as user
+    visit events_path
+    click_on 'Cadastrar Perfil'
     fill_in 'Título', with: ''
     fill_in 'Sobre mim', with: ''
     fill_in 'Cidade', with: ''
@@ -118,17 +106,11 @@ describe 'User register a profile' do
   end
 
   it 'with blank fields for gender and pronoun' do
-    service = ExternalEventApi::UserFindEmailService
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+    user = create(:user, first_name: 'João')
 
-    visit root_path
-    click_on 'Criar conta'
-    fill_in 'E-mail', with: 'joao@campuscode.com'
-    fill_in 'Senha', with: 'password'
-    fill_in 'Confirme sua senha', with: 'password'
-    fill_in 'Nome', with: 'João'
-    fill_in 'Sobrenome', with: 'Almeida'
-    click_on 'Cadastrar'
+    login_as user
+    visit events_path
+    click_on 'Cadastrar Perfil'
     select('Outro', from: 'Pronome')
     fill_in 'Outro Pronome', with: ''
     select('Outro', from: 'Gênero')
@@ -142,17 +124,11 @@ describe 'User register a profile' do
   end
 
   it 'with invalid network' do
-    service = ExternalEventApi::UserFindEmailService
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+    user = create(:user, first_name: 'João')
 
-    visit root_path
-    click_on 'Criar conta'
-    fill_in 'E-mail', with: 'joao@campuscode.com'
-    fill_in 'Senha', with: 'password'
-    fill_in 'Confirme sua senha', with: 'password'
-    fill_in 'Nome', with: 'João'
-    fill_in 'Sobrenome', with: 'Almeida'
-    click_on 'Cadastrar'
+    login_as user
+    visit events_path
+    click_on 'Cadastrar Perfil'
     fill_in 'Título', with: 'Instrutor / Desenvolvedor'
     fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
     attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
@@ -197,48 +173,31 @@ describe 'User register a profile' do
     expect(page).to have_content('Cadastre seu perfil')
   end
 
-  it 'and select public and private fields' do
-    service = ExternalEventApi::UserFindEmailService
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(true)
+  it 'and select private fields' do
+    user = create(:user, first_name: 'João')
 
-    visit root_path
-    click_on 'Criar conta'
-    fill_in 'E-mail', with: 'joao@campuscode.com'
-    fill_in 'Senha', with: 'password'
-    fill_in 'Confirme sua senha', with: 'password'
-    fill_in 'Nome', with: 'João'
-    fill_in 'Sobrenome', with: 'Almeida'
-    click_on 'Cadastrar'
+    login_as user
+    visit events_path
+    click_on 'Cadastrar Perfil'
     fill_in 'Título', with: 'Instrutor / Desenvolvedor'
     fill_in 'Sobre mim', with: 'Sou João, desenvolvedor Ruby com foco em Ruby on Rails.'
     select('Ele/Dele', from: 'Pronome')
+    uncheck 'Exibir Pronome'
     fill_in 'Cidade', with: 'Florianópolis'
+    uncheck 'Exibir Cidade'
     fill_in 'Data de Nascimento', with: '1999-01-25'
+    uncheck 'Exibir Data de Nascimento'
     select('Masculino', from: 'Gênero')
+    check 'Exibir Gênero'
     attach_file('Foto de Perfil',  Rails.root.join('spec/fixtures/puts.png'))
-    fill_in 'Meu site', with: 'https://www.joaotutoriais.com/'
-    fill_in 'Youtube', with: 'https://www.youtube.com/@JoãoTutoriais'
-    fill_in 'Twitter', with: 'https://x.com/joao'
-    fill_in 'GitHub', with: 'https://github.com/joaorsalmeida'
-    fill_in 'Facebook', with: 'https://www.facebook.com/joaoalmeida'
     click_on 'Criar perfil'
 
-    profile_test = Profile.first
-    networks = profile_test.social_networks
+    profile = Profile.first
     expect(current_path).to eq(events_path)
     expect(page).to have_content('Perfil cadastrado com sucesso.')
-    expect(profile_test.title).to eq('Instrutor / Desenvolvedor')
-    expect(profile_test.about_me).to eq('Sou João, desenvolvedor Ruby com foco em Ruby on Rails.')
-    expect(profile_test.pronoun).to eq('Ele/Dele')
-    expect(profile_test.city).to eq('Florianópolis')
-    expect(profile_test.birth.strftime('%d/%m/%Y')).to eq('25/01/1999')
-    expect(profile_test.gender).to eq('Masculino')
-    expect(profile_test.profile_picture.attached?).to eq(true)
-    expect(networks.length).to eq(5)
-    expect(networks.find_by(url: 'https://www.youtube.com/@JoãoTutoriais').present?).to eq(true)
-    expect(networks.find_by(url: 'https://www.joaotutoriais.com/').present?).to eq(true)
-    expect(networks.find_by(url: 'https://x.com/joao').present?).to eq(true)
-    expect(networks.find_by(url: 'https://github.com/joaorsalmeida').present?).to eq(true)
-    expect(networks.find_by(url: 'https://www.facebook.com/joaoalmeida').present?).to eq(true)
+    expect(profile.display_pronoun).to eq(false)
+    expect(profile.display_gender).to eq(true)
+    expect(profile.display_city).to eq(false)
+    expect(profile.display_birth).to eq(false)
   end
 end

--- a/spec/system/profile/user_views_the_public_profile_spec.rb
+++ b/spec/system/profile/user_views_the_public_profile_spec.rb
@@ -35,7 +35,6 @@ describe 'User views the public profile' do
 
     visit profile_path(profile.username)
 
-    expect(page).to have_content('Perfil')
     expect(page).to have_content('José de Jesus')
     expect(page).to have_content('Instrutor')
     expect(page).to have_content('Olá, meu nome é José e eu sou um instrutor de Ruby on Rails')

--- a/spec/system/profile/user_views_the_public_profile_spec.rb
+++ b/spec/system/profile/user_views_the_public_profile_spec.rb
@@ -26,7 +26,7 @@ describe 'User views the public profile' do
     user = create(:user, first_name: 'José', last_name: 'de Jesus')
     image = fixture_file_upload(Rails.root.join('spec/fixtures/puts.png'))
     profile = create(:profile, title: 'Instrutor', about_me: 'Olá, meu nome é José e eu sou um instrutor de Ruby on Rails',
-                     user: user, profile_picture: image)
+                     user: user, profile_picture: image, pronoun: 'Ele/Dele', city: 'Florianópolis', birth: '1999-01-02', gender: 'Masculino')
     create(:social_network, url: 'https://www.youtube.com/@JoséTutoriais', social_network_type: 1, profile: profile)
     create(:social_network, url: 'https://www.josetutoriais.com/', social_network_type: :my_site, profile: profile)
     create(:social_network, url: 'https://x.com/jose', social_network_type: :x, profile: profile)
@@ -38,6 +38,10 @@ describe 'User views the public profile' do
     expect(page).to have_content('José de Jesus')
     expect(page).to have_content('Instrutor')
     expect(page).to have_content('Olá, meu nome é José e eu sou um instrutor de Ruby on Rails')
+    expect(page).to have_content('Ele/Dele')
+    expect(page).to have_content('Florianópolis')
+    expect(page).to have_content('02/01/1999')
+    expect(page).to have_content('Masculino')
     expect(page).to have_css("img[src*='puts.png']")
     expect(page).to have_link('Youtube')
     expect(page).to have_link('Meu Site')
@@ -53,7 +57,7 @@ describe 'User views the public profile' do
     user = create(:user, first_name: 'José', last_name: 'de Jesus')
     image = fixture_file_upload(Rails.root.join('spec/fixtures/puts.png'))
     profile = create(:profile, title: 'Instrutor', about_me: 'Olá, meu nome é José e eu sou um instrutor de Ruby on Rails',
-                     user: user, profile_picture: image)
+                     user: user, profile_picture: image, pronoun: 'Ele/Dele', city: 'Florianópolis', birth: '1999-01-02', gender: 'Masculino')
     create(:social_network, profile: profile)
 
     login_as user

--- a/spec/system/profile/user_views_the_public_profile_spec.rb
+++ b/spec/system/profile/user_views_the_public_profile_spec.rb
@@ -89,4 +89,25 @@ describe 'User views the public profile' do
     expect(current_path).to eq(events_path)
     expect(page).to have_content('O usuário Thiago não existe.')
   end
+
+  it 'and set private fields' do
+    user = create(:user, first_name: 'José', last_name: 'de Jesus')
+    image = fixture_file_upload(Rails.root.join('spec/fixtures/puts.png'))
+    create(:profile, title: 'Instrutor', about_me: 'Olá, meu nome é José e eu sou um instrutor de Ruby on Rails',
+                     user: user, profile_picture: image, pronoun: 'Ele/Dele', city: 'Florianópolis', birth: '1999-01-02', gender: 'Masculino',
+                     display_gender: false, display_pronoun: false, display_city: false, display_birth: false)
+
+    login_as user
+    visit events_path
+    click_on 'Meu Perfil'
+
+    expect(page).not_to have_content('Pronomes')
+    expect(page).not_to have_content('Ele/Dele')
+    expect(page).not_to have_content('Cidade')
+    expect(page).not_to have_content('Florianópolis')
+    expect(page).not_to have_content('Birth')
+    expect(page).not_to have_content('02/01/1999')
+    expect(page).not_to have_content('Gênero')
+    expect(page).not_to have_content('Masculino')
+  end
 end


### PR DESCRIPTION
Foram feitos ajustes com base nos feedbacks dos clientes, passados no dia 28/01, que incluí: 
- Alteração de hierarquia visual.
- Campos de pronome, gênero, cidade e data de nascimento para perfil.
- Exibição das novas informações na tela show de perfil.
- Opções para selecionar se a informação deve ser exibida ou não.

Exibição das novas informações:
![image](https://github.com/user-attachments/assets/53ac084b-61c3-445c-a92c-88efc2496382)

Formulário com novas informações: 
![image](https://github.com/user-attachments/assets/31df7c11-cb20-4840-bdde-56483819c90b)

Resolve #75 