### PR TITLE
feat: Adicionado tela de visualização de tarefas cadastradas para uma programação

### DIFF
--- a/app/controllers/curriculum_tasks_controller.rb
+++ b/app/controllers/curriculum_tasks_controller.rb
@@ -14,6 +14,10 @@ class CurriculumTasksController < ApplicationController
     render :new, status: :unprocessable_entity
   end
 
+  def show
+    @task = @curriculum.curriculum_tasks.find_by(id: params[:id])
+  end
+
   private
 
   def set_curriculum
@@ -22,6 +26,6 @@ class CurriculumTasksController < ApplicationController
   end
 
   def set_curriculum_task_params
-    params.require(:curriculum_task).permit(:title, :description, :cestificate_requirement)
+    params.require(:curriculum_task).permit(:title, :description, :certificate_requirement)
   end
 end

--- a/app/views/curriculum_tasks/show.html.erb
+++ b/app/views/curriculum_tasks/show.html.erb
@@ -1,0 +1,14 @@
+<%= go_back_button(schedule_item_path(@curriculum.schedule_item_code)) %>
+
+<div class='border-2 rounded-3xl p-3'> 
+  <div class="flex items-center justify-between">
+    <h2 class="heading-2"><%= @task.title %></h2>
+    <div class='w-32 p-1 text-center border  rounded-3xl text-white bg-[#6e487c]'>
+      <b><%= CurriculumTask.human_enum_name(:certificate_requirement, @task.certificate_requirement) %></b>
+    </div>
+  </div>
+  <div>
+    <%= @task.description %>
+  </div>
+</div>
+

--- a/app/views/schedule_items/show.html.erb
+++ b/app/views/schedule_items/show.html.erb
@@ -37,7 +37,7 @@
     <% if @curriculum.curriculum_tasks.any? %>
       <% @curriculum.curriculum_tasks.each do |task| %>
         <div>
-          <%= task.title %>
+          <%= link_to task.title, curriculum_curriculum_task_path(@curriculum, task.id), class: 'link-primary' %>
         </div>
       <% end %>
     <% else %>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -81,6 +81,8 @@ pt-BR:
     form:
       title: 'Adicionar tarefa a programação:'
       save: 'Adicionar'
+    show:
+      task: 'Tarefa'
   home:
     index:
       register: 'Cadastre-se Agora'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,6 @@ Rails.application.routes.draw do
   resources :profiles, only: %i[ show new create ], param: :username
   resources :curriculums, only: [] do
     resources :curriculum_contents, only: %i[ new create show ]
-    resources :curriculum_tasks, only: %i[ new create ]
+    resources :curriculum_tasks, only: %i[ new create show ]
   end
 end

--- a/spec/requests/curriculum_task/user_view_curriculum_task_details_spec.rb
+++ b/spec/requests/curriculum_task/user_view_curriculum_task_details_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'User view a curriculum task', type: :request do
+  it 'and must be authenticated' do
+    user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    curriculum_task = create(:curriculum_task, curriculum: curriculum, title: 'Tarefa Teste', description: 'Descrição teste')
+
+    get curriculum_curriculum_task_path(curriculum, curriculum_task)
+
+    expect(response).to redirect_to new_user_session_path
+  end
+
+  it 'and must be the owner' do
+    first_user = create(:user)
+    second_user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: first_user, schedule_item_code: schedule_item.id)
+    curriculum_task = create(:curriculum_task, curriculum: curriculum, title: 'Tarefa Teste', description: 'Descrição teste')
+
+    login_as second_user
+    get curriculum_curriculum_task_path(curriculum, curriculum_task)
+
+    expect(response).to redirect_to events_path
+  end
+end

--- a/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
+++ b/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'User view curriculum task details', type: :system do
+  it 'with success' do
+    user = create(:user)
+    event =  [ build(:event, name: 'Ruby on Rails', description: 'Introdução ao Rails com TDD',
+                  start_date: 7.days.from_now, end_date: 14.days.from_now, url: 'www.meuevento.com/eventos/Ruby-on-Rails',
+                  event_type: 'Presencial', location: 'Juiz de Fora', participant_limit: 100, status: 'Publicado') ]
+    schedule_items = [ build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD') ]
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_items.first.id)
+    create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+
+    allow(Event).to receive(:all).and_return(event)
+    allow(Event).to receive(:find).and_return(event.first)
+    allow(event.first).to receive(:schedule_items).and_return(schedule_items)
+    allow(ScheduleItem).to receive(:find).and_return(schedule_items.first)
+
+    login_as user, scope: :user
+    visit root_path
+    click_on 'Ruby on Rails'
+    click_on 'TDD com Rails'
+    click_on 'Exercício Rails'
+
+    expect(page).to have_content 'Exercício Rails'
+    expect(page).to have_content 'Seu primeiro exercício'
+    expect(page).to have_content 'Opcional'
+  end
+
+  it 'and must be authenticated' do
+    user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+
+    visit curriculum_curriculum_task_path(curriculum, task)
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se'
+  end
+
+  it 'and must be the curriculum task owner' do
+    user = create(:user)
+    second_user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+
+    login_as second_user
+    visit curriculum_curriculum_task_path(curriculum, task)
+
+    expect(current_path).to eq events_path
+    expect(page).to have_content 'Conteúdo indisponível!'
+  end
+
+  it 'and go back to previous page' do
+    user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+
+    login_as user
+    visit curriculum_curriculum_task_path(curriculum, task)
+    click_on 'VOLTAR'
+
+    expect(current_path).to eq schedule_item_path(schedule_item.id)
+  end
+end


### PR DESCRIPTION
Resolve #94 

Adicionada a tela de visualização de uma tarefa anexada a uma programação;
Implementação de testes para garantirem que apenas o usuário correto poderá acessar a página;
Implementação de um botão 'voltar', que retorna o usuário para a tela da programação a qual a tarefa está anexada;

Tela da programação
![image](https://github.com/user-attachments/assets/44f3ce0d-773e-4d70-8128-a79b2730d7b4)

Tela de detalhes da tarefa
![image](https://github.com/user-attachments/assets/bb5f8349-a918-4ca9-b221-46ea192aaddb)