### PR TITLE
feat: Adiciona associação entre curriculum_task e curriculum_content

### DIFF
--- a/app/controllers/curriculum_tasks_controller.rb
+++ b/app/controllers/curriculum_tasks_controller.rb
@@ -1,8 +1,10 @@
 class CurriculumTasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_curriculum
+  before_action :check_curriculum_content_owner, only: %i[ create ]
 
   def new
+    @curriculum_contents = @curriculum.curriculum_contents
     @curriculum_task = @curriculum.curriculum_tasks.build
   end
 
@@ -10,6 +12,7 @@ class CurriculumTasksController < ApplicationController
     @curriculum_task = @curriculum.curriculum_tasks.build(set_curriculum_task_params)
     return redirect_to schedule_item_path(@curriculum.schedule_item_code), notice: t('curriculum_tasks.create.success') if @curriculum_task.save
 
+    @curriculum_contents = @curriculum.curriculum_contents
     flash.now[:alert] = t('curriculum_tasks.create.error')
     render :new, status: :unprocessable_entity
   end
@@ -26,6 +29,17 @@ class CurriculumTasksController < ApplicationController
   end
 
   def set_curriculum_task_params
-    params.require(:curriculum_task).permit(:title, :description, :certificate_requirement)
+    params.require(:curriculum_task).permit(:title, :description, :certificate_requirement, curriculum_content_ids: [])
+  end
+
+  def check_curriculum_content_owner
+    return if params[:curriculum_task][:curriculum_content_ids].blank?
+    contents = params[:curriculum_task][:curriculum_content_ids].reject(&:blank?)
+    contents.each do |content|
+      unless @curriculum.curriculum_contents.find_by(id: content)
+        flash.now["alert"] = "Conteúdo indisponível"
+        redirect_to schedule_item_path(@curriculum.schedule_item_code)
+      end
+    end
   end
 end

--- a/app/models/curriculum_content.rb
+++ b/app/models/curriculum_content.rb
@@ -1,9 +1,14 @@
 class CurriculumContent < ApplicationRecord
   belongs_to :curriculum
   belongs_to :event_content
-
+  has_many :curriculum_task_contents
+  has_many :curriculum_tasks, through: :curriculum_task_contents
   validates_uniqueness_of :curriculum_id, scope: :event_content_id
   validate :must_be_event_content_owner
+
+  def title
+    event_content.title
+  end
 
   protected
 

--- a/app/models/curriculum_task.rb
+++ b/app/models/curriculum_task.rb
@@ -1,7 +1,8 @@
 class CurriculumTask < ApplicationRecord
   belongs_to :curriculum
   enum :certificate_requirement, { mandatory: 1, optional: 0 }, default: :optional
-
+  has_many :curriculum_task_contents
+  has_many :curriculum_contents, through: :curriculum_task_contents
   validates :title, :description, :certificate_requirement, presence: true
   validates_uniqueness_of :title, scope: :curriculum_id
 end

--- a/app/models/curriculum_task_content.rb
+++ b/app/models/curriculum_task_content.rb
@@ -1,0 +1,4 @@
+class CurriculumTaskContent < ApplicationRecord
+  belongs_to :curriculum_task
+  belongs_to :curriculum_content
+end

--- a/app/views/curriculum_tasks/_form.html.erb
+++ b/app/views/curriculum_tasks/_form.html.erb
@@ -42,6 +42,18 @@
         <% end %>
       </div>
 
+      <div class="col-span-2 mt-2">
+      <%= f.label :curriculum_content_ids, class: "label-primary" %>
+        <% if curriculum_contents.blank? %>
+          <p class="mt-2"> <%= t('.no_contents') %></p>
+        <% else %>
+          <%= f.collection_check_boxes(:curriculum_content_ids, curriculum_contents, :id, :title) do |b| %>
+              <%= b.check_box %>
+              <%= b.label(class: "text-sm text-gray-900 mr-2") %>
+          <% end %>
+        <% end %>
+    </div>
+
       <div class="mt-5 flex justify-end">
         <%= f.submit t('.save'), class: 'btn-primary'%>
       </div>

--- a/app/views/curriculum_tasks/new.html.erb
+++ b/app/views/curriculum_tasks/new.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <%= render 'form', curriculum_task: @curriculum_task, curriculum: @curriculum %>
+  <%= render 'form', curriculum_task: @curriculum_task, curriculum: @curriculum, curriculum_contents: @curriculum_contents %>
 </div>

--- a/app/views/curriculum_tasks/show.html.erb
+++ b/app/views/curriculum_tasks/show.html.erb
@@ -10,5 +10,13 @@
   <div>
     <%= @task.description %>
   </div>
-</div>
 
+  <% if @task.curriculum_contents.any? %>
+    <h3 class='text-2xl font-semibold text-blue-500 mb-2'> <%= t('.attached_contents') %></h3>
+    <% @task.curriculum_contents.each do |content|  %>
+      <div>
+        <%= link_to content.title, curriculum_curriculum_content_path(@curriculum, content), class: 'link-primary' %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/model/curriculum_task.pt-BR.yml
+++ b/config/locales/model/curriculum_task.pt-BR.yml
@@ -10,3 +10,4 @@ pt-BR:
         certificate_requirements: 
           mandatory: 'Obrigatória'
           optional: 'Opcional'
+        curriculum_content_ids: 'Anexar Conteúdos:'

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -81,8 +81,10 @@ pt-BR:
     form:
       title: 'Adicionar tarefa a programação:'
       save: 'Adicionar'
+      no_contents: 'Não existem conteúdos disponíveis'
     show:
       task: 'Tarefa'
+      attached_contents: 'Material de apoio'
   home:
     index:
       register: 'Cadastre-se Agora'

--- a/db/migrate/20250131200408_create_curriculum_task_contents.rb
+++ b/db/migrate/20250131200408_create_curriculum_task_contents.rb
@@ -1,0 +1,10 @@
+class CreateCurriculumTaskContents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :curriculum_task_contents do |t|
+      t.references :curriculum_task, null: false, foreign_key: true
+      t.references :curriculum_content, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_30_140852) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_31_200408) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -56,6 +56,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_30_140852) do
     t.datetime "updated_at", null: false
     t.index ["curriculum_id"], name: "index_curriculum_contents_on_curriculum_id"
     t.index ["event_content_id"], name: "index_curriculum_contents_on_event_content_id"
+  end
+
+  create_table "curriculum_task_contents", force: :cascade do |t|
+    t.integer "curriculum_task_id", null: false
+    t.integer "curriculum_content_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["curriculum_content_id"], name: "index_curriculum_task_contents_on_curriculum_content_id"
+    t.index ["curriculum_task_id"], name: "index_curriculum_task_contents_on_curriculum_task_id"
   end
 
   create_table "curriculum_tasks", force: :cascade do |t|
@@ -150,6 +159,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_30_140852) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "curriculum_contents", "curriculums"
   add_foreign_key "curriculum_contents", "event_contents"
+  add_foreign_key "curriculum_task_contents", "curriculum_contents"
+  add_foreign_key "curriculum_task_contents", "curriculum_tasks"
   add_foreign_key "curriculum_tasks", "curriculums"
   add_foreign_key "curriculums", "users"
   add_foreign_key "event_contents", "users"

--- a/spec/factories/curriculum_task_contents.rb
+++ b/spec/factories/curriculum_task_contents.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :curriculum_task_content do
+    curriculum_task
+    curriculum_content
+  end
+end

--- a/spec/models/curriculum_content_spec.rb
+++ b/spec/models/curriculum_content_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe CurriculumContent, type: :model do
     it { should validate_uniqueness_of(:curriculum_id).scoped_to(:event_content_id) }
     it { should belong_to(:curriculum) }
     it { should belong_to(:event_content) }
+    it { should have_many(:curriculum_task_contents) }
+    it { should have_many(:curriculum_tasks).through(:curriculum_task_contents) }
   end
 
   context '.must_be_event_content_owner' do
@@ -21,6 +23,17 @@ RSpec.describe CurriculumContent, type: :model do
       curriculum_content = CurriculumContent.new(curriculum: curriculum, event_content: first_user_event_content)
 
       expect(curriculum_content).not_to be_valid
+    end
+  end
+
+  context '.title' do
+    it 'must return the event content title' do
+      user = create(:user)
+      event_content = create(:event_content, title: 'Conteudo teste', user: user)
+      curriculum = create(:curriculum, user: user)
+      curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: event_content)
+
+      expect(curriculum_content.title).to eq 'Conteudo teste'
     end
   end
 end

--- a/spec/models/curriculum_spec.rb
+++ b/spec/models/curriculum_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Curriculum, type: :model do
+  it { should belong_to(:user) }
 end

--- a/spec/models/curriculum_task_content_spec.rb
+++ b/spec/models/curriculum_task_content_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe CurriculumTaskContent, type: :model do
+  it { should belong_to(:curriculum_content) }
+  it { should belong_to(:curriculum_task) }
+end

--- a/spec/models/curriculum_task_spec.rb
+++ b/spec/models/curriculum_task_spec.rb
@@ -10,5 +10,7 @@ RSpec.describe CurriculumTask, type: :model do
     it { should define_enum_for(:certificate_requirement).with_default(:optional) }
     subject { create(:curriculum_task) }
     it { validate_uniqueness_of(:title).scoped_to(:curriculum_id) }
+    it { should have_many(:curriculum_task_contents) }
+    it { should have_many(:curriculum_contents).through(:curriculum_task_contents) }
   end
 end

--- a/spec/requests/curriculum_task/user_register_task_for_your_curriculum_spec.rb
+++ b/spec/requests/curriculum_task/user_register_task_for_your_curriculum_spec.rb
@@ -37,4 +37,19 @@ describe 'User register a new task to a curriculum', type: :request do
     expect(response).to redirect_to events_path
     expect(flash[:alert]).to eq('Conteúdo indisponível!')
   end
+
+  it 'and must be the curriculum content owner' do
+    first_user = create(:user)
+    curriculum = create(:curriculum, user: first_user)
+    event_content = create(:event_content, user: first_user, title: 'Ruby on Rails')
+    first_user_curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: event_content)
+    second_user = create(:user)
+    second_user_curriculum = create(:curriculum, user: second_user)
+
+    login_as second_user
+    post curriculum_curriculum_tasks_path(second_user_curriculum), params: { curriculum_task: { title: 'Tarefa 01', description: 'Descrição', certificate_requirement: :optional, curriculum_content_ids: [ first_user_curriculum_content.id ] } }
+
+    expect(CurriculumTask.count).to eq 0
+    expect(response).to redirect_to schedule_item_path(second_user_curriculum.schedule_item_code)
+  end
 end

--- a/spec/system/curriculum_task/user_register_task_for_your_curriculum_spec.rb
+++ b/spec/system/curriculum_task/user_register_task_for_your_curriculum_spec.rb
@@ -40,6 +40,34 @@ describe 'User register task for your schedule item curriculum', type: :system, 
     expect(page).to have_content 'Tarefa 01'
   end
 
+  it 'and attach an content to task' do
+    user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    first_content = create(:event_content, user: user, title: 'Workshop Stimulus')
+    second_content = create(:event_content, user: user, title: 'Ruby para Iniciantes')
+    create(:curriculum_content, curriculum: curriculum, event_content: first_content)
+    create(:curriculum_content, curriculum: curriculum, event_content: second_content)
+
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+
+    login_as user
+    visit schedule_item_path(schedule_item.id)
+    click_on 'Adicionar tarefa'
+    fill_in 'Título', with: 'Tarefa 01'
+    fill_in 'Descrição', with: 'Lorem ipsum'
+    choose 'Obrigatória'
+    check 'Workshop Stimulus'
+    check 'Ruby para Iniciantes'
+    click_on 'Adicionar'
+
+    expect(CurriculumTask.count).to eq 1
+    expect(CurriculumTaskContent.count).to eq 2
+    expect(current_path).to eq schedule_item_path(schedule_item.id)
+    expect(page).to have_content 'Tarefa adicionada com sucesso!'
+    expect(page).to have_content 'Tarefa 01'
+  end
+
   it 'and must fill all required fields' do
     user = create(:user)
     schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')

--- a/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
+++ b/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
@@ -8,7 +8,11 @@ describe 'User view curriculum task details', type: :system do
                   event_type: 'Presencial', location: 'Juiz de Fora', participant_limit: 100, status: 'Publicado') ]
     schedule_items = [ build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD') ]
     curriculum = create(:curriculum, user: user, schedule_item_code: schedule_items.first.id)
-    create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+    content = create(:event_content, user: user, title: 'Conteúdo Rails')
+    curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: content)
+    task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+    create(:curriculum_task_content, curriculum_task: task, curriculum_content: curriculum_content)
+
 
     allow(Event).to receive(:all).and_return(event)
     allow(Event).to receive(:find).and_return(event.first)
@@ -24,6 +28,26 @@ describe 'User view curriculum task details', type: :system do
     expect(page).to have_content 'Exercício Rails'
     expect(page).to have_content 'Seu primeiro exercício'
     expect(page).to have_content 'Opcional'
+    expect(page).to have_content 'Conteúdo Rails'
+  end
+
+  it 'and have contents attached' do
+    user = create(:user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    content = create(:event_content, user: user, title: 'Conteúdo Rails')
+    curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: content)
+    task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
+    create(:curriculum_task_content, curriculum_task: task, curriculum_content: curriculum_content)
+
+
+    login_as user, scope: :user
+    visit curriculum_curriculum_task_path(curriculum, task)
+
+    expect(page).to have_content 'Exercício Rails'
+    expect(page).to have_content 'Seu primeiro exercício'
+    expect(page).to have_content 'Opcional'
+    expect(page).to have_content 'Conteúdo Rails'
   end
 
   it 'and must be authenticated' do


### PR DESCRIPTION
Resolve #79 

Adiciona join table para associar curriculum_content a curriculum_task
Exibe mensagem quando não há conteúdos cadastrados a uma programação
Exibe check boxes ao formulário de tarefas para anexar conteúdos
Listagem de conteúdos anexados a tarefa na tela de detalhes da mesma

- Mensagem quando não há conteúdos disponíveis
![image](https://github.com/user-attachments/assets/76924e80-e594-4dad-bc2f-8d052c817e39)

- Check boxes no formulário
![image](https://github.com/user-attachments/assets/a1617966-83ea-4cdb-b0dd-4c47df3aead7)

- Listagem de conteúdos na tela de detalhes da tarefa
![image](https://github.com/user-attachments/assets/2a0588df-940f-41c4-a92f-ce8098f1eb8b)
