### PR TITLE
Adicionado a coluna "code" nas models Curriculum, CurriculumContent, CurriculumTask e EventContent

### DIFF
--- a/app/controllers/curriculum_contents_controller.rb
+++ b/app/controllers/curriculum_contents_controller.rb
@@ -13,13 +13,14 @@ class CurriculumContentsController < ApplicationController
   end
 
   def show
-    @curriculum_content = @curriculum.curriculum_contents.find(params[:id])
+    @curriculum_content = @curriculum.curriculum_contents.find_by(code: params[:code])
+    redirect_to schedule_item_path(@curriculum.schedule_item_code), alert: t('curriculum_contents.set_curriculum.content_unavailable') if @curriculum_content.nil?
   end
 
   private
 
   def set_curriculum
-    @curriculum = current_user.curriculums.find_by(id: params[:curriculum_id])
+    @curriculum = current_user.curriculums.find_by(code: params[:curriculum_code])
     redirect_to events_path, alert: t('curriculum_contents.set_curriculum.content_unavailable') unless @curriculum
   end
 

--- a/app/controllers/curriculum_tasks_controller.rb
+++ b/app/controllers/curriculum_tasks_controller.rb
@@ -18,13 +18,14 @@ class CurriculumTasksController < ApplicationController
   end
 
   def show
-    @task = @curriculum.curriculum_tasks.find_by(id: params[:id])
+    @task = @curriculum.curriculum_tasks.find_by(code: params[:code])
+    redirect_to schedule_item_path(@curriculum.schedule_item_code), alert: t('curriculum_tasks.set_curriculum.error') if @task.nil?
   end
 
   private
 
   def set_curriculum
-    @curriculum = current_user.curriculums.find_by(id: params[:curriculum_id])
+    @curriculum = current_user.curriculums.find_by(code: params[:curriculum_code])
     redirect_to events_path, alert: t('curriculum_tasks.set_curriculum.error') unless @curriculum
   end
 

--- a/app/controllers/event_contents_controller.rb
+++ b/app/controllers/event_contents_controller.rb
@@ -43,11 +43,8 @@ class EventContentsController < ApplicationController
   end
 
   def set_event_content
-    begin
-      @event_content = current_user.event_contents.find(params[:id])
-    rescue
-      redirect_to events_path, notice: t('event_contents.set_event_content.content_unavailable')
-    end
+      @event_content = current_user.event_contents.find_by(code: params[:code])
+      redirect_to events_path, alert: t('event_contents.set_event_content.content_unavailable') if @event_content.nil?
   end
 
   def set_event_content_files

--- a/app/models/curriculum.rb
+++ b/app/models/curriculum.rb
@@ -3,4 +3,21 @@ class Curriculum < ApplicationRecord
   has_many :curriculum_contents
   has_many :event_contents, through: :curriculum_contents
   has_many :curriculum_tasks
+
+  validates :code, presence: true
+
+  after_initialize :generate_code, if: :new_record?
+
+  def generate_code
+    loop do
+      self.code = SecureRandom.alphanumeric(8).upcase
+      break unless Curriculum.where(code: code).exists?
+    end
+  end
+
+  # Necessário para sobreescrever o metodo to_param, ao chamar o objeto Curriculum irá retornar o código em vez do id
+  # Ex: example_path(@curriculum) o rails vai interpretar @curriculum como curriculum.code ao invés do padrão que é o curriculum.id
+  def to_param
+    code
+  end
 end

--- a/app/models/curriculum.rb
+++ b/app/models/curriculum.rb
@@ -8,16 +8,16 @@ class Curriculum < ApplicationRecord
 
   after_initialize :generate_code, if: :new_record?
 
+  def to_param
+    code
+  end
+
+  protected
+
   def generate_code
     loop do
       self.code = SecureRandom.alphanumeric(8).upcase
       break unless Curriculum.where(code: code).exists?
     end
-  end
-
-  # Necessário para sobreescrever o metodo to_param, ao chamar o objeto Curriculum irá retornar o código em vez do id
-  # Ex: example_path(@curriculum) o rails vai interpretar @curriculum como curriculum.code ao invés do padrão que é o curriculum.id
-  def to_param
-    code
   end
 end

--- a/app/models/curriculum.rb
+++ b/app/models/curriculum.rb
@@ -3,8 +3,9 @@ class Curriculum < ApplicationRecord
   has_many :curriculum_contents
   has_many :event_contents, through: :curriculum_contents
   has_many :curriculum_tasks
-
   validates :code, presence: true
+  validates :code, uniqueness: true
+
 
   after_initialize :generate_code, if: :new_record?
 

--- a/app/models/curriculum_content.rb
+++ b/app/models/curriculum_content.rb
@@ -5,9 +5,19 @@ class CurriculumContent < ApplicationRecord
   has_many :curriculum_tasks, through: :curriculum_task_contents
   validates_uniqueness_of :curriculum_id, scope: :event_content_id
   validate :must_be_event_content_owner
+  validates :code, presence: true
+
+  after_initialize :generate_code, if: :new_record?
 
   def title
     event_content.title
+  end
+
+  def generate_code
+    loop do
+      self.code = SecureRandom.alphanumeric(8).upcase
+      break unless CurriculumContent.where(code: code).exists?
+    end
   end
 
   protected

--- a/app/models/curriculum_content.rb
+++ b/app/models/curriculum_content.rb
@@ -13,14 +13,18 @@ class CurriculumContent < ApplicationRecord
     event_content.title
   end
 
+  def to_param
+    code
+  end
+  
+  protected
+
   def generate_code
     loop do
       self.code = SecureRandom.alphanumeric(8).upcase
       break unless CurriculumContent.where(code: code).exists?
     end
   end
-
-  protected
 
   def must_be_event_content_owner
     return if event_content&.user == curriculum&.user

--- a/app/models/curriculum_content.rb
+++ b/app/models/curriculum_content.rb
@@ -6,6 +6,7 @@ class CurriculumContent < ApplicationRecord
   validates_uniqueness_of :curriculum_id, scope: :event_content_id
   validate :must_be_event_content_owner
   validates :code, presence: true
+  validates :code, uniqueness: true
 
   after_initialize :generate_code, if: :new_record?
 
@@ -16,7 +17,7 @@ class CurriculumContent < ApplicationRecord
   def to_param
     code
   end
-  
+
   protected
 
   def generate_code

--- a/app/models/curriculum_task.rb
+++ b/app/models/curriculum_task.rb
@@ -3,9 +3,9 @@ class CurriculumTask < ApplicationRecord
   enum :certificate_requirement, { mandatory: 1, optional: 0 }, default: :optional
   has_many :curriculum_task_contents
   has_many :curriculum_contents, through: :curriculum_task_contents
-  validates :title, :description, :certificate_requirement, presence: true
+  validates :title, :description, :certificate_requirement, :code, presence: true
+  validates :code, uniqueness: true
   validates_uniqueness_of :title, scope: :curriculum_id
-  validates :code, presence: true
 
   after_initialize :generate_code, if: :new_record?
 

--- a/app/models/curriculum_task.rb
+++ b/app/models/curriculum_task.rb
@@ -5,4 +5,14 @@ class CurriculumTask < ApplicationRecord
   has_many :curriculum_contents, through: :curriculum_task_contents
   validates :title, :description, :certificate_requirement, presence: true
   validates_uniqueness_of :title, scope: :curriculum_id
+  validates :code, presence: true
+
+  after_initialize :generate_code, if: :new_record?
+
+  def generate_code
+    loop do
+      self.code = SecureRandom.alphanumeric(8).upcase
+      break unless CurriculumTask.where(code: code).exists?
+    end
+  end
 end

--- a/app/models/curriculum_task.rb
+++ b/app/models/curriculum_task.rb
@@ -9,6 +9,12 @@ class CurriculumTask < ApplicationRecord
 
   after_initialize :generate_code, if: :new_record?
 
+  def to_param
+    code
+  end
+
+  protected
+
   def generate_code
     loop do
       self.code = SecureRandom.alphanumeric(8).upcase

--- a/app/models/event_content.rb
+++ b/app/models/event_content.rb
@@ -10,6 +10,13 @@ class EventContent < ApplicationRecord
   validates :title, presence: true
   validate :check_external_video_url
   has_rich_text :description
+  validates :code, presence: true
+
+  after_initialize :generate_code, if: :new_record?
+
+  def to_param
+    code
+  end
 
   protected
 
@@ -34,6 +41,13 @@ class EventContent < ApplicationRecord
       unless external_video_url.include?('youtube.com') || external_video_url.include?('vimeo.com')
         errors.add(:external_video_url, 'é inválida.')
       end
+    end
+  end
+
+  def generate_code
+    loop do
+      self.code = SecureRandom.alphanumeric(8).upcase
+      break unless CurriculumTask.where(code: code).exists?
     end
   end
 end

--- a/app/models/event_content.rb
+++ b/app/models/event_content.rb
@@ -7,10 +7,10 @@ class EventContent < ApplicationRecord
   has_many_attached :files
   validate :must_have_less_than_five_files
   validate :valid_file_size
-  validates :title, presence: true
+  validates :title, :code, presence: true
+  validates :code, uniqueness: true
   validate :check_external_video_url
   has_rich_text :description
-  validates :code, presence: true
 
   after_initialize :generate_code, if: :new_record?
 

--- a/app/views/schedule_items/show.html.erb
+++ b/app/views/schedule_items/show.html.erb
@@ -26,7 +26,7 @@
     <% if @curriculum.curriculum_contents.any? %>
       <% @curriculum.curriculum_contents.each do |content| %>
         <div>
-          <%= link_to content.event_content.title, curriculum_curriculum_content_path(@curriculum, content.id), class: 'link_primary' %>
+          <%= link_to content.event_content.title, curriculum_curriculum_content_path(@curriculum, content.code), class: 'link_primary' %>
         </div>
       <% end %>
     <% else %>
@@ -44,7 +44,7 @@
     <% if @curriculum.curriculum_tasks.any? %>
       <% @curriculum.curriculum_tasks.each do |task| %>
         <div>
-          <%= link_to task.title, curriculum_curriculum_task_path(@curriculum, task.id), class: 'link-primary' %>
+          <%= link_to task.title, curriculum_curriculum_task_path(@curriculum, task.code), class: 'link_primary' %>
         </div>
       <% end %>
     <% else %>

--- a/app/views/schedule_items/show.html.erb
+++ b/app/views/schedule_items/show.html.erb
@@ -26,7 +26,7 @@
     <% if @curriculum.curriculum_contents.any? %>
       <% @curriculum.curriculum_contents.each do |content| %>
         <div>
-          <%= link_to content.event_content.title, curriculum_curriculum_content_path(@curriculum, content.code), class: 'link_primary' %>
+          <%= link_to content.event_content.title, curriculum_curriculum_content_path(@curriculum, content), class: 'link_primary' %>
         </div>
       <% end %>
     <% else %>
@@ -44,7 +44,7 @@
     <% if @curriculum.curriculum_tasks.any? %>
       <% @curriculum.curriculum_tasks.each do |task| %>
         <div>
-          <%= link_to task.title, curriculum_curriculum_task_path(@curriculum, task.code), class: 'link_primary' %>
+          <%= link_to task.title, curriculum_curriculum_task_path(@curriculum, task), class: 'link_primary' %>
         </div>
       <% end %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,8 @@ Rails.application.routes.draw do
   resources :event_tasks, only: %i[ index show new create edit update ]
   resources :schedule_items, only: %i[ show ]
   resources :profiles, only: %i[ show new create ], param: :username
-  resources :curriculums, only: [] do
-    resources :curriculum_contents, only: %i[ new create show ]
-    resources :curriculum_tasks, only: %i[ new create show ]
+  resources :curriculums, only: [], param: :code do
+    resources :curriculum_contents, only: %i[ new create show ], param: :code
+    resources :curriculum_tasks, only: %i[ new create show ],  param: :code
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   root "home#index"
 
   resources :events, only: %i[ index show ], param: :code
-  resources :event_contents, only: %i[ index show new create edit update ]
+  resources :event_contents, only: %i[ index show new create edit update ], param: :code
   resources :event_tasks, only: %i[ index show new create edit update ]
   resources :schedule_items, only: %i[ show ]
   resources :profiles, only: %i[ show new create ], param: :username

--- a/db/migrate/20250204135505_add_code_to_curriculum_content.rb
+++ b/db/migrate/20250204135505_add_code_to_curriculum_content.rb
@@ -1,0 +1,6 @@
+class AddCodeToCurriculumContent < ActiveRecord::Migration[8.0]
+  def change
+    add_column :curriculum_contents, :code, :string
+    add_index :curriculum_contents, :code, unique: true
+  end
+end

--- a/db/migrate/20250204141828_add_code_to_curriculum_task.rb
+++ b/db/migrate/20250204141828_add_code_to_curriculum_task.rb
@@ -1,0 +1,6 @@
+class AddCodeToCurriculumTask < ActiveRecord::Migration[8.0]
+  def change
+    add_column :curriculum_tasks, :code, :string
+    add_index :curriculum_tasks, :code, unique: true
+  end
+end

--- a/db/migrate/20250204144319_add_code_to_curriculum.rb
+++ b/db/migrate/20250204144319_add_code_to_curriculum.rb
@@ -1,0 +1,6 @@
+class AddCodeToCurriculum < ActiveRecord::Migration[8.0]
+  def change
+    add_column :curriculums, :code, :string
+    add_index :curriculums, :code, unique: true
+  end
+end

--- a/db/migrate/20250204151541_add_code_to_event_content.rb
+++ b/db/migrate/20250204151541_add_code_to_event_content.rb
@@ -1,0 +1,6 @@
+class AddCodeToEventContent < ActiveRecord::Migration[8.0]
+  def change
+    add_column :event_contents, :code, :string
+    add_index :event_contents, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_144319) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_151541) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -97,6 +97,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_144319) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.string "external_video_url"
+    t.string "code"
+    t.index ["code"], name: "index_event_contents_on_code", unique: true
     t.index ["user_id"], name: "index_event_contents_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_02_203346) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_144319) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -54,6 +54,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_203346) do
     t.integer "event_content_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code"
+    t.index ["code"], name: "index_curriculum_contents_on_code", unique: true
     t.index ["curriculum_id"], name: "index_curriculum_contents_on_curriculum_id"
     t.index ["event_content_id"], name: "index_curriculum_contents_on_event_content_id"
   end
@@ -71,9 +73,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_203346) do
     t.integer "curriculum_id", null: false
     t.string "title"
     t.text "description"
-    t.integer "certificate_requirement", default: 0, null: false
+    t.integer "certificate_requirement", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code"
+    t.index ["code"], name: "index_curriculum_tasks_on_code", unique: true
     t.index ["curriculum_id"], name: "index_curriculum_tasks_on_curriculum_id"
   end
 
@@ -82,6 +86,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_203346) do
     t.string "schedule_item_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code"
+    t.index ["code"], name: "index_curriculums_on_code", unique: true
     t.index ["user_id"], name: "index_curriculums_on_user_id"
   end
 

--- a/spec/models/curriculum_content_spec.rb
+++ b/spec/models/curriculum_content_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe CurriculumContent, type: :model do
     it { should belong_to(:event_content) }
     it { should have_many(:curriculum_task_contents) }
     it { should have_many(:curriculum_tasks).through(:curriculum_task_contents) }
+    it { validate_presence_of(:code) }
+    it { validate_uniqueness_of(:code) }
   end
 
   context '.must_be_event_content_owner' do
@@ -34,6 +36,30 @@ RSpec.describe CurriculumContent, type: :model do
       curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: event_content)
 
       expect(curriculum_content.title).to eq 'Conteudo teste'
+    end
+  end
+
+  context '.to_param' do
+    it 'must return the curriculum_content.code' do
+      user = create(:user)
+      event_content = create(:event_content, title: 'Conteudo teste', user: user)
+      curriculum = create(:curriculum, user: user)
+      curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: event_content, code: 'ABCDE')
+
+      expect(curriculum_content.to_param).to eq 'ABCDE'
+    end
+  end
+
+  context '.generate_code' do
+    it 'must return an unique code' do
+      user = create(:user)
+      event_content = create(:event_content, title: 'Conteudo teste', user: user)
+      curriculum = create(:curriculum, user: user)
+      second_curriculum = create(:curriculum, user: user)
+      first_curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: event_content)
+      second_curriculum_content = create(:curriculum_content, curriculum: second_curriculum, event_content: event_content)
+
+      expect(first_curriculum_content.code).not_to eq second_curriculum_content.code
     end
   end
 end

--- a/spec/models/curriculum_spec.rb
+++ b/spec/models/curriculum_spec.rb
@@ -2,4 +2,23 @@ require 'rails_helper'
 
 RSpec.describe Curriculum, type: :model do
   it { should belong_to(:user) }
+  it { validate_presence_of(:code) }
+  it { validate_uniqueness_of(:code) }
+
+  context '.to_param' do
+    it 'must return the curriculum.code' do
+      curriculum = create(:curriculum, code: 'ABCDE')
+
+      expect(curriculum.to_param).to eq 'ABCDE'
+    end
+  end
+
+  context '.generate_code' do
+    it 'must return an unique code' do
+      first_curriculum = create(:curriculum)
+      second_curriculum = create(:curriculum)
+
+      expect(first_curriculum.code).not_to eq second_curriculum.code
+    end
+  end
 end

--- a/spec/models/curriculum_task_spec.rb
+++ b/spec/models/curriculum_task_spec.rb
@@ -12,5 +12,24 @@ RSpec.describe CurriculumTask, type: :model do
     it { validate_uniqueness_of(:title).scoped_to(:curriculum_id) }
     it { should have_many(:curriculum_task_contents) }
     it { should have_many(:curriculum_contents).through(:curriculum_task_contents) }
+    it { validate_presence_of(:code) }
+    it { validate_uniqueness_of(:code) }
+  end
+
+  context '.to_param' do
+    it 'must return the curriculum_task.code' do
+      curriculum_task = create(:curriculum_task, code: 'ABCDE')
+
+      expect(curriculum_task.to_param).to eq 'ABCDE'
+    end
+  end
+
+  context '.generate_code' do
+    it 'must return an unique code' do
+      first_curriculum_task = create(:curriculum_task)
+      second_curriculum_task = create(:curriculum_task)
+
+      expect(first_curriculum_task.code).not_to eq second_curriculum_task.code
+    end
   end
 end

--- a/spec/models/event_content_spec.rb
+++ b/spec/models/event_content_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe EventContent, type: :model do
     it { should belong_to(:user) }
     it { should have_many(:event_task_contents) }
     it { should have_many(:event_tasks).through(:event_task_contents) }
+    it { validate_presence_of(:code) }
+    it { validate_uniqueness_of(:code) }
   end
 
   context '.must_have_less_than_five_files' do
@@ -44,6 +46,23 @@ RSpec.describe EventContent, type: :model do
                                        external_video_url: 'https://app.campuscode.com.br/')
 
       expect(event_content).not_to be_valid
+    end
+  end
+
+  context '.to_param' do
+    it 'must return the event_content.code' do
+      event_content = create(:event_content, code: 'ABCDE')
+
+      expect(event_content.to_param).to eq 'ABCDE'
+    end
+  end
+
+  context '.generate_code' do
+    it 'must return an unique code' do
+      first_content = create(:event_content)
+      second_content = create(:event_content)
+
+      expect(first_content.code).not_to eq second_content.code
     end
   end
 end

--- a/spec/system/curriculum_content/user_view_curriculum_content_details_spec.rb
+++ b/spec/system/curriculum_content/user_view_curriculum_content_details_spec.rb
@@ -86,14 +86,14 @@ describe 'User access curriculum content details', type: :system do
   it 'and curriculum content doesnt exists' do
     user = create(:user)
     create(:profile, user: user)
-    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
-    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    schedule_item = build(:schedule_item, code: 99, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
 
     login_as user
     visit curriculum_curriculum_content_path(curriculum, 'ABCDE')
 
-    expect(current_path).to eq schedule_item_path(schedule_item.id)
+    expect(current_path).to eq schedule_item_path(schedule_item.code)
     expect(page).to have_content 'Conteúdo indisponível!'
   end
 end

--- a/spec/system/curriculum_content/user_view_curriculum_content_details_spec.rb
+++ b/spec/system/curriculum_content/user_view_curriculum_content_details_spec.rb
@@ -53,7 +53,7 @@ describe 'User access curriculum content details', type: :system do
     curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: content)
 
     login_as second_user
-    visit curriculum_curriculum_content_path(curriculum, curriculum_content.code)
+    visit curriculum_curriculum_content_path(curriculum, curriculum_content)
 
     expect(current_path).to eq events_path
     expect(page).to have_content 'Conteúdo indisponível!'
@@ -69,7 +69,7 @@ describe 'User access curriculum content details', type: :system do
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
 
     login_as user
-    visit curriculum_curriculum_content_path(curriculum, curriculum_content.code)
+    visit curriculum_curriculum_content_path(curriculum, curriculum_content)
     click_on 'VOLTAR'
 
     expect(current_path).to eq schedule_item_path(schedule_item.id)

--- a/spec/system/curriculum_content/user_view_curriculum_content_details_spec.rb
+++ b/spec/system/curriculum_content/user_view_curriculum_content_details_spec.rb
@@ -53,7 +53,7 @@ describe 'User access curriculum content details', type: :system do
     curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: content)
 
     login_as second_user
-    visit curriculum_curriculum_content_path(curriculum, curriculum_content)
+    visit curriculum_curriculum_content_path(curriculum, curriculum_content.code)
 
     expect(current_path).to eq events_path
     expect(page).to have_content 'Conteúdo indisponível!'
@@ -69,9 +69,23 @@ describe 'User access curriculum content details', type: :system do
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
 
     login_as user
-    visit curriculum_curriculum_content_path(curriculum, curriculum_content)
+    visit curriculum_curriculum_content_path(curriculum, curriculum_content.code)
     click_on 'VOLTAR'
 
     expect(current_path).to eq schedule_item_path(schedule_item.id)
+  end
+
+  it 'and curriculum content doesnt exists' do
+    user = create(:user)
+    create(:profile, user: user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+
+    login_as user
+    visit curriculum_curriculum_content_path(curriculum, 'ABCDE')
+
+    expect(current_path).to eq schedule_item_path(schedule_item.id)
+    expect(page).to have_content 'Conteúdo indisponível!'
   end
 end

--- a/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
+++ b/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
@@ -100,14 +100,14 @@ describe 'User view curriculum task details', type: :system do
   it 'and curriculum task doesnt exists' do
     user = create(:user)
     create(:profile, user: user)
-    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
-    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    schedule_item = build(:schedule_item, code: 99, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
 
     login_as user
     visit curriculum_curriculum_task_path(curriculum, 'ABCDE')
 
-    expect(current_path).to eq schedule_item_path(schedule_item.id)
+    expect(current_path).to eq schedule_item_path(schedule_item.code)
     expect(page).to have_content 'Conteúdo indisponível!'
   end
 end

--- a/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
+++ b/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
@@ -42,7 +42,7 @@ describe 'User view curriculum task details', type: :system do
 
 
     login_as user, scope: :user
-    visit curriculum_curriculum_task_path(curriculum, task)
+    visit curriculum_curriculum_task_path(curriculum, task.code)
 
     expect(page).to have_content 'Exercício Rails'
     expect(page).to have_content 'Seu primeiro exercício'
@@ -56,7 +56,7 @@ describe 'User view curriculum task details', type: :system do
     curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
     task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
 
-    visit curriculum_curriculum_task_path(curriculum, task)
+    visit curriculum_curriculum_task_path(curriculum, task.code)
 
     expect(current_path).to eq new_user_session_path
     expect(page).to have_content 'Para continuar, faça login ou registre-se'
@@ -71,7 +71,7 @@ describe 'User view curriculum task details', type: :system do
     task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
 
     login_as second_user
-    visit curriculum_curriculum_task_path(curriculum, task)
+    visit curriculum_curriculum_task_path(curriculum, task.code)
 
     expect(current_path).to eq events_path
     expect(page).to have_content 'Conteúdo indisponível!'
@@ -86,9 +86,23 @@ describe 'User view curriculum task details', type: :system do
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
 
     login_as user
-    visit curriculum_curriculum_task_path(curriculum, task)
+    visit curriculum_curriculum_task_path(curriculum, task.code)
     click_on 'VOLTAR'
 
     expect(current_path).to eq schedule_item_path(schedule_item.id)
+  end
+
+  it 'and curriculum task doesnt exists' do
+    user = create(:user)
+    create(:profile, user: user)
+    schedule_item = build(:schedule_item, id: 99, title: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+
+    login_as user
+    visit curriculum_curriculum_task_path(curriculum, 'ABCDE')
+
+    expect(current_path).to eq schedule_item_path(schedule_item.id)
+    expect(page).to have_content 'Conteúdo indisponível!'
   end
 end

--- a/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
+++ b/spec/system/curriculum_task/user_view_curriculum_task_details_spec.rb
@@ -42,7 +42,7 @@ describe 'User view curriculum task details', type: :system do
 
 
     login_as user, scope: :user
-    visit curriculum_curriculum_task_path(curriculum, task.code)
+    visit curriculum_curriculum_task_path(curriculum, task)
 
     expect(page).to have_content 'Exercício Rails'
     expect(page).to have_content 'Seu primeiro exercício'
@@ -56,7 +56,7 @@ describe 'User view curriculum task details', type: :system do
     curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.id)
     task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
 
-    visit curriculum_curriculum_task_path(curriculum, task.code)
+    visit curriculum_curriculum_task_path(curriculum, task)
 
     expect(current_path).to eq new_user_session_path
     expect(page).to have_content 'Para continuar, faça login ou registre-se'
@@ -71,7 +71,7 @@ describe 'User view curriculum task details', type: :system do
     task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício', certificate_requirement: :optional)
 
     login_as second_user
-    visit curriculum_curriculum_task_path(curriculum, task.code)
+    visit curriculum_curriculum_task_path(curriculum, task)
 
     expect(current_path).to eq events_path
     expect(page).to have_content 'Conteúdo indisponível!'
@@ -86,7 +86,7 @@ describe 'User view curriculum task details', type: :system do
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
 
     login_as user
-    visit curriculum_curriculum_task_path(curriculum, task.code)
+    visit curriculum_curriculum_task_path(curriculum, task)
     click_on 'VOLTAR'
 
     expect(current_path).to eq schedule_item_path(schedule_item.id)


### PR DESCRIPTION
Resolve #38 

Foi adicionado a coluna "code" nas models Curriculum, CurriculumContent, CurriculumTask e EventContent

Agora ao acessar o "show" de algum dessas models mencionadas, o parametro na url é o :code

![Screenshot from 2025-02-04 13-32-34](https://github.com/user-attachments/assets/f0d85d84-1693-4bcf-9e1a-d39b84019908)
![Screenshot from 2025-02-04 13-32-47](https://github.com/user-attachments/assets/3fc063b4-5cee-42d6-989c-b27ebcf46cd2)
![image](https://github.com/user-attachments/assets/265a1021-20f8-4642-bb9f-eac451b127ea)

