### PR TITLE
fix/111 refatoracao api envio de email e recebimento de codigo unico

### DIFF
--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -12,10 +12,21 @@ module ApiHelper
   class EventClient
     EVENT_URL = Rails.configuration.event_api['base'].freeze
     SCHEDULE_ITEMS_URL = Rails.configuration.event_api['schedule_items']
+    SPEAKER_AUTH_URL = Rails.configuration.event_api['speakers_auth']
 
     def self.get_schedule_items(token:, event_code:)
       url = "#{EVENT_URL}#{SCHEDULE_ITEMS_URL % { token: token, event_code: event_code }}"
       Faraday.get(url)
+    end
+
+    def self.post_auth_speaker_email_and_return_code(email)
+      connection = Faraday.new do |conn|
+        conn.adapter Faraday.default_adapter
+        conn.headers['Content-Type'] = 'application/json'
+      end
+      url = "#{EVENT_URL}#{SPEAKER_AUTH_URL}"
+      email = { email: email }
+      connection.post(url, email.to_json)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,8 @@ class User < ApplicationRecord
     response = ExternalEventApi::UserFindEmailService.new(email: self.email).call
     if response.present? && response.include?("error")
       errors.add(:base, response["error"])
-    elsif response.present? && response.include?("token")
-      self.token = response["token"]
+    elsif response.present? && response.include?("code")
+      self.token = response["code"]
     else
       errors.add(:base, "Algo deu errado, contate o responsável.")
     end

--- a/app/services/external_event_api/user_find_email_service.rb
+++ b/app/services/external_event_api/user_find_email_service.rb
@@ -8,12 +8,7 @@ class ExternalEventApi::UserFindEmailService < ApplicationService
   def presence_fetch_api_email?
     result = nil
     begin
-      connection = Faraday.new do |conn|
-        conn.adapter Faraday.default_adapter
-        conn.headers['Content-Type'] = 'application/json'
-      end
-      email = { email: kwargs[:email] }
-      response = connection.post('http://localhost:3001/api/v1/speakers', email.to_json)
+      response = EventClient.post_auth_speaker_email_and_return_code(kwargs[:email])
       result = JSON.parse(response.body)
     rescue StandardError => error
       Rails.logger.error(error)

--- a/config/event_api.yml
+++ b/config/event_api.yml
@@ -1,3 +1,4 @@
 shared:
   base: 'http://localhost:3001/api/v1/'
   schedule_items: 'speakers/%{token}/schedules/%{event_code}'
+  speakers_auth: 'speakers'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe User, type: :model do
 
   context '#api_auth_user' do
     it 'with success' do
-      token = { "token"=> "ABCD1234" }
-      allow_any_instance_of(ExternalEventApi::UserFindEmailService).to receive(:call).and_return(token)
+      code = { "code"=> "ABCD1234" }
+      allow_any_instance_of(ExternalEventApi::UserFindEmailService).to receive(:call).and_return(code)
       user = User.new(email: 'joao@email.com', first_name: 'João', last_name: 'Almeida', password: '123456')
 
       user.save

--- a/spec/system/profile/user_register_a_profile_spec.rb
+++ b/spec/system/profile/user_register_a_profile_spec.rb
@@ -10,8 +10,8 @@ describe 'User register a profile', type: :system do
 
   it 'with success' do
     service = ExternalEventApi::UserFindEmailService
-    token = { "token" => "ABCD1234" }
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(token)
+    code = { "code" => "ABCD1234" }
+    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(code)
 
     visit root_path
     click_on 'Criar conta'

--- a/spec/system/user_sign_up_spec.rb
+++ b/spec/system/user_sign_up_spec.rb
@@ -24,8 +24,8 @@ describe 'Speacker create account', type: :system do
 
   it 'with success' do
     service = ExternalEventApi::UserFindEmailService
-    token = { "token"=> "ABCD1234" }
-    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(token)
+    code = { "code"=> "ABCD1234" }
+    allow_any_instance_of(service).to receive(:presence_fetch_api_email?).and_return(code)
 
     visit root_path
     click_on 'Criar conta'


### PR DESCRIPTION
Altera o parametro de envio para /api/v1/speakers do app de Eventos, trocando de token para code.
Cria novo método post_auth_speaker_email_and_return_code dentro de event_client para centralizar as rotas.

Resolve #111 