### PR TITLE
feat/137 Melhoria no endpoint de currículo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Exibe as tarefas e conteúdos de um currículo, que representa todos os dados pa
   "curriculum": {
     "curriculum_contents": [
       {
+        "last_update": "07/02/2025"
         "code": "MH0IBQ8O",
         "title": "Ruby PDF",
         "description": "\u003Cstrong\u003EDescrição Ruby PDF\u003C/strong\u003E",
@@ -76,6 +77,7 @@ Exibe as tarefas e conteúdos de um currículo, que representa todos os dados pa
         ]
       }
     ],
+    "tasks_available": true
     "curriculum_tasks": [
       {
         "code": "FNRVUEUB",
@@ -104,6 +106,7 @@ Exibe as tarefas e conteúdos de um currículo, que representa todos os dados pa
 
 * curriculum_contents: Conteúdos;
   - code: Código de identificação;
+  - last_update: Última atualização;
   - title: Título;
   - description: Descrição com texto enriquecido;
   - external_video_url: Link de um video externo dentro de um iframe para exibição;
@@ -117,6 +120,7 @@ Exibe as tarefas e conteúdos de um currículo, que representa todos os dados pa
   - certificate_requirement: Tarefa obrigatória ou opcional;
 * attached_contents: Conteúdos anexados a tarefa;
   - attached_content_code: Código de referencia de um conteúdo;
+* tasks_available: Disponibilidade das tarefas;
   
 ## Contribuidores
 

--- a/app/controllers/api/v1/curriculums_controller.rb
+++ b/app/controllers/api/v1/curriculums_controller.rb
@@ -2,7 +2,8 @@ class Api::V1::CurriculumsController < Api::V1::ApiController
   helper ApplicationHelper
   def show
     @curriculum = Curriculum.find_by(schedule_item_code: params[:schedule_item_code])
-
+    schedule_item = ScheduleItem.find(schedule_item_code: params[:schedule_item_code], token: @curriculum.user.token)
+    @tasks_available = Date.today >= schedule_item.event.start_date
     render status: :not_found, json: { error: I18n.t('not_found_error', model: Curriculum.model_name.human) } if @curriculum.nil?
   end
 end

--- a/app/controllers/api/v1/curriculums_controller.rb
+++ b/app/controllers/api/v1/curriculums_controller.rb
@@ -2,8 +2,9 @@ class Api::V1::CurriculumsController < Api::V1::ApiController
   helper ApplicationHelper
   def show
     @curriculum = Curriculum.find_by(schedule_item_code: params[:schedule_item_code])
+    return render status: :not_found, json: { error: I18n.t('not_found_error', model: Curriculum.model_name.human) } if @curriculum.nil?
+
     schedule_item = ScheduleItem.find(schedule_item_code: params[:schedule_item_code], token: @curriculum.user.token)
-    @tasks_available = Date.today >= schedule_item.event.start_date
-    render status: :not_found, json: { error: I18n.t('not_found_error', model: Curriculum.model_name.human) } if @curriculum.nil?
+    @tasks_available = Date.today >= schedule_item.event_start_date
   end
 end

--- a/app/models/schedule_item.rb
+++ b/app/models/schedule_item.rb
@@ -11,6 +11,9 @@ class ScheduleItem
   attribute :responsible_email, :string
   attribute :schedule_type, :string
   attribute :code, :string
+  attribute :event_code, :string
+  attribute :event_start_date, :datetime
+  attribute :event_end_date, :datetime
 
   @@instances = []
   def initialize(**params)

--- a/app/services/external_event_api/find_schedule_item_service.rb
+++ b/app/services/external_event_api/find_schedule_item_service.rb
@@ -12,6 +12,9 @@ class ExternalEventApi::FindScheduleItemService < ApplicationService
       if response.success?
         json_response = JSON.parse(response.body)
         schedule_item = ScheduleItem.new(**json_response)
+        schedule_item.event_code = json_response["event"]["code"]
+        schedule_item.event_start_date = json_response["event"]["start_date"]
+        schedule_item.event_end_date = json_response["event"]["end_date"]
       end
     rescue StandardError => error
       Rails.logger.error(error)

--- a/app/views/api/v1/curriculums/show.json.jbuilder
+++ b/app/views/api/v1/curriculums/show.json.jbuilder
@@ -2,7 +2,7 @@ if @curriculum.present?
   json.curriculum do
     if @curriculum.curriculum_contents.any?
       json.curriculum_contents @curriculum.curriculum_contents do |content|
-        json.code content.event_content.code
+        json.code content.code
         json.title content.event_content.title
         json.description content.event_content.description.body
         if content.event_content.external_video_url.present?
@@ -26,7 +26,7 @@ if @curriculum.present?
           json.certificate_requirement task.translated_certificate_requirement(task.certificate_requirement)
           if task.curriculum_contents.any?
             json.attached_contents task.curriculum_contents do |content|
-              json.attached_content_code content.event_content.code
+              json.attached_content_code content.code
             end
           end
         else

--- a/app/views/api/v1/curriculums/show.json.jbuilder
+++ b/app/views/api/v1/curriculums/show.json.jbuilder
@@ -5,7 +5,9 @@ if @curriculum.present?
         json.code content.event_content.code
         json.title content.event_content.title
         json.description content.event_content.description.body
-        json.external_video_url render_external_video(content.event_content.external_video_url)
+        if content.event_content.external_video_url.present?
+          json.external_video_url render_external_video(content.event_content.external_video_url)
+        end
         if content.event_content.files.attached?
           json.files content.event_content.files do |file|
             json.filename file.filename
@@ -14,6 +16,7 @@ if @curriculum.present?
         end
       end
     end
+    json.tasks_available @tasks_available
     if  @curriculum.curriculum_tasks.any?
       json.curriculum_tasks @curriculum.curriculum_tasks do |task|
         json.code task.code

--- a/app/views/api/v1/curriculums/show.json.jbuilder
+++ b/app/views/api/v1/curriculums/show.json.jbuilder
@@ -3,6 +3,7 @@ if @curriculum.present?
     if @curriculum.curriculum_contents.any?
       json.curriculum_contents @curriculum.curriculum_contents do |content|
         json.code content.code
+        json.last_update content.event_content.update_histories.last.creation_date.strftime('%d/%m/%Y') if content.event_content.update_histories.any?
         json.title content.event_content.title
         json.description content.event_content.description.body
         if content.event_content.external_video_url.present?

--- a/app/views/api/v1/curriculums/show.json.jbuilder
+++ b/app/views/api/v1/curriculums/show.json.jbuilder
@@ -19,14 +19,18 @@ if @curriculum.present?
     json.tasks_available @tasks_available
     if  @curriculum.curriculum_tasks.any?
       json.curriculum_tasks @curriculum.curriculum_tasks do |task|
-        json.code task.code
-        json.title task.title
-        json.description task.description
-        json.certificate_requirement task.translated_certificate_requirement(task.certificate_requirement)
-        if task.curriculum_contents.any?
-          json.attached_contents task.curriculum_contents do |content|
-            json.attached_content_code content.event_content.code
+        if @tasks_available
+          json.code task.code
+          json.title task.title
+          json.description task.description
+          json.certificate_requirement task.translated_certificate_requirement(task.certificate_requirement)
+          if task.curriculum_contents.any?
+            json.attached_contents task.curriculum_contents do |content|
+              json.attached_content_code content.event_content.code
+            end
           end
+        else
+          json.title task.title
         end
       end
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_180608) do
     t.integer "curriculum_id", null: false
     t.string "title"
     t.text "description"
-    t.integer "certificate_requirement", default: 0, null: false
+    t.integer "certificate_requirement", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code"

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { "Tech Conference" }
     url { "www.techconf.com" }
     description { "Something" }
-    start_date { "2025-02-01T14:00:00.000-03:00" }
+    start_date { start_time_rand }
     end_date { end_time_rand }
     event_type { "inperson" }
     address { "Main Street, n° 670, New York City" }
@@ -19,6 +19,11 @@ FactoryBot.define do
        status: status, created_at: created_at, updated_at: updated_at, code: code)
     }
   end
+end
+
+
+def start_time_rand
+  rand(1..10).day.from_now
 end
 
 def end_time_rand

--- a/spec/factories/schedule_item.rb
+++ b/spec/factories/schedule_item.rb
@@ -8,10 +8,21 @@ FactoryBot.define do
     schedule_type { 'in-person' }
     start_time { 1.days.from_now }
     end_time { 2.days.from_now }
+    event_code { SecureRandom.alphanumeric(8).upcase }
+    event_start_date { start_time_rand }
+    event_end_date { end_time_rand }
 
     initialize_with {
       new(name: name, description: description, responsible_name: responsible_name, responsible_email: responsible_email, schedule_type: schedule_type,
-          start_time: start_time, end_time: end_time, code: code)
+          start_time: start_time, end_time: end_time, code: code, event_code: event_code, event_start_date: event_start_date, event_end_date: event_end_date)
     }
   end
+end
+
+def start_time_rand
+  rand(1..10).day.from_now
+end
+
+def end_time_rand
+  rand(11..20).day.from_now
 end

--- a/spec/requests/api/v1/curriculum_api_spec.rb
+++ b/spec/requests/api/v1/curriculum_api_spec.rb
@@ -91,16 +91,18 @@ describe 'Curriculum API' do
       first_task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory)
       create(:curriculum_task, curriculum: curriculum, title: 'Exercício Stimulus', description: 'Seu primeiro exercício stimulus', certificate_requirement: :optional)
       create(:curriculum_task_content, curriculum_task: first_task, curriculum_content: first_curriculum_content)
-      create(:curriculum_task_content, curriculum_task: first_task, curriculum_content: second_curriculum_content)
 
       allow(ScheduleItem).to receive(:find).and_return(schedule_item)
       get "/api/v1/curriculums/#{schedule_item.code}"
 
       expect(response).to have_http_status :success
       expect(response.content_type).to include('application/json')
+      curriculum_response = response.parsed_body['curriculum']
       tasks_response = curriculum_response['curriculum_tasks']
-      expect(tasks_response.length).to eq 1
-      expect(tasks_response.last).to eq "As tarefas só serão disponibilizadas após o início do evento (#{event.start_date.strftime('%d/%m/%Y')})"
+      expect(tasks_response.length).to eq 2
+      expect(curriculum_response['tasks_available']).to eq false
+      expect(tasks_response[0]).to eq({ title: 'Exercício Rails' })
+      expect(tasks_response[1]).to eq({ title: 'Exercício Stimulus' })
     end
   end
 end

--- a/spec/requests/api/v1/curriculum_api_spec.rb
+++ b/spec/requests/api/v1/curriculum_api_spec.rb
@@ -9,12 +9,12 @@ describe 'Curriculum API' do
       files = [ fixture_file_upload(Rails.root.join('spec/fixtures/capi.png')),
                 fixture_file_upload(Rails.root.join('spec/fixtures/nota-ufjf.pdf')),
                 fixture_file_upload(Rails.root.join('spec/fixtures/joker.mp4')) ]
-      first_content = create(:event_content, title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>', code: 'ABCD1234',
+      first_content = create(:event_content, title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>',
                               external_video_url: 'https://www.youtube.com/watch?v=idaXF2Er4TU', files: files, user: user)
       second_content = create(:event_content, title: 'Ruby Video', description: 'Apresentação sobre TDD',
-                              external_video_url: 'https://www.youtube.com/watch?v=2DvrRadXwWY', user: user, code: '74851234')
+                              external_video_url: 'https://www.youtube.com/watch?v=2DvrRadXwWY', user: user)
       third_content = create(:event_content, title: 'Stimulus', description: 'PDF sobre Stimulus',
-                              external_video_url: 'https://www.youtube.com/watch?v=1cw6qO1EYGw', user: user, code: 'WERAG234')
+                              external_video_url: 'https://www.youtube.com/watch?v=1cw6qO1EYGw', user: user)
       first_curriculum_content = create(:curriculum_content, id: 1, curriculum: curriculum, event_content: first_content, code: 'XLR8BE10')
       second_curriculum_content = create(:curriculum_content, id: 2, curriculum: curriculum, event_content: second_content, code: 'CODIGO15')
       create(:curriculum_content, curriculum: curriculum, event_content: third_content, code: 'CODIGO26')
@@ -32,31 +32,19 @@ describe 'Curriculum API' do
       tasks_response = curriculum_response['curriculum_tasks']
       contents_response = curriculum_response['curriculum_contents']
       expect(contents_response.length).to eq 3
-      expect(contents_response[0]['code']).to eq 'ABCD1234'
-      expect(contents_response[0]['title']).to eq 'Ruby PDF'
-      expect(contents_response[0]['description']).to eq '<strong>Descrição Ruby PDF</strong>'
-      expect(contents_response[0]['external_video_url']).to eq "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/idaXF2Er4TU' frameborder='0' allowfullscreen></iframe>"
-      expect(contents_response[0]['files'][0]['filename']).to eq 'capi.png'
-      expect(contents_response[0]['files'][1]['filename']).to eq 'nota-ufjf.pdf'
-      expect(contents_response[0]['files'][2]['filename']).to eq 'joker.mp4'
-      expect(contents_response[1]['code']).to eq '74851234'
-      expect(contents_response[1]['title']).to eq 'Ruby Video'
-      expect(contents_response[1]['description']).to eq 'Apresentação sobre TDD'
-      expect(contents_response[1]['external_video_url']).to eq "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/2DvrRadXwWY' frameborder='0' allowfullscreen></iframe>"
-      expect(contents_response[2]['title']).to eq 'Stimulus'
-      expect(contents_response[2]['description']).to eq 'PDF sobre Stimulus'
-      expect(contents_response[2]['external_video_url']).to eq "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/1cw6qO1EYGw' frameborder='0' allowfullscreen></iframe>"
+      expect(contents_response[0].deep_symbolize_keys).to include({ code: 'XLR8BE10', title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>',
+                                                                    external_video_url: "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/idaXF2Er4TU' frameborder='0' allowfullscreen></iframe>",
+                                                                    files: [ { file_download_url: "http://www.example.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--34bb1868318e92534296ce473e5723673680545c/capi.png", filename: 'capi.png' },
+                                                                             { file_download_url: "http://www.example.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--c334c3494c13b74df05f58b8166423c4642953bc/nota-ufjf.pdf", filename: 'nota-ufjf.pdf' },
+                                                                             { file_download_url: "http://www.example.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MywicHVyIjoiYmxvYl9pZCJ9fQ==--2c7e74e916ab7d45606cc8b7c8384ae32b2e8300/joker.mp4", filename: 'joker.mp4' } ] })
+      expect(contents_response[1].deep_symbolize_keys).to eq({ code: 'CODIGO15', title: 'Ruby Video', description: 'Apresentação sobre TDD',
+                                                               external_video_url: "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/2DvrRadXwWY' frameborder='0' allowfullscreen></iframe>"  })
+      expect(contents_response[2].deep_symbolize_keys).to eq({ code: 'CODIGO26', title: 'Stimulus', description: 'PDF sobre Stimulus',
+                                                               external_video_url: "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/1cw6qO1EYGw' frameborder='0' allowfullscreen></iframe>" })
       expect(tasks_response.length).to eq 2
-      expect(tasks_response[0]['code']).to eq 'CODIGO37'
-      expect(tasks_response[0]['title']).to eq 'Exercício Rails'
-      expect(tasks_response[0]['description']).to eq 'Seu primeiro exercício ruby'
-      expect(tasks_response[0]['certificate_requirement']).to eq 'Obrigatória'
-      expect(tasks_response[0]['attached_contents'][0]['attached_content_code']).to eq 'ABCD1234'
-      expect(tasks_response[0]['attached_contents'][1]['attached_content_code']).to eq '74851234'
-      expect(tasks_response[1]['code']).to eq 'CODIGO48'
-      expect(tasks_response[1]['title']).to eq 'Exercício Stimulus'
-      expect(tasks_response[1]['description']).to eq 'Seu primeiro exercício stimulus'
-      expect(tasks_response[1]['certificate_requirement']).to eq 'Opcional'
+      expect(tasks_response[0].deep_symbolize_keys).to eq({ code: 'CODIGO37', title: 'Exercício Rails', description: 'Seu primeiro exercício ruby', certificate_requirement: 'Obrigatória',
+                                                            attached_contents: [ { attached_content_code: 'XLR8BE10' }, { attached_content_code: 'CODIGO15' } ] })
+      expect(tasks_response[1].deep_symbolize_keys).to eq({ code: 'CODIGO48', title: 'Exercício Stimulus', description: 'Seu primeiro exercício stimulus', certificate_requirement: 'Opcional' })
     end
 
     it 'with a schedule item that does not exist' do
@@ -76,7 +64,7 @@ describe 'Curriculum API' do
       allow(Curriculum).to receive(:find_by).and_raise(ActiveRecord::ActiveRecordError)
       get "/api/v1/curriculums/#{schedule_item.code}"
 
-      expect(response).to have_http_status 500
+      expect(response).to have_http_status :internal_server_error
       expect(response.content_type).to include('application/json')
       expect(response.parsed_body['error']).to eq 'Algo deu errado.'
     end
@@ -100,8 +88,8 @@ describe 'Curriculum API' do
       tasks_response = json_response['curriculum']['curriculum_tasks']
       expect(tasks_response.length).to eq 2
       expect(json_response['curriculum']['tasks_available']).to eq false
-      expect(tasks_response[0].keys).to eq [ "title" ]
-      expect(tasks_response[1].keys).to eq [ "title" ]
+      expect(tasks_response[0].deep_symbolize_keys).to eq({ title: 'Exercício Rails' })
+      expect(tasks_response[1].deep_symbolize_keys).to eq({ title: 'Exercício Stimulus' })
     end
   end
 end

--- a/spec/requests/api/v1/curriculum_api_spec.rb
+++ b/spec/requests/api/v1/curriculum_api_spec.rb
@@ -4,7 +4,7 @@ describe 'Curriculum API' do
   context 'GET /api/v1/curriculums/:schedule_item_code' do
     it 'with success' do
       user = create(:user)
-      schedule_item = build(:schedule_item, code: 99, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+      schedule_item = build(:schedule_item, code: 99, name: 'TDD com Rails', description: 'Introdução a programação com TDD', event_start_date: Date.today)
       curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
       files = [ fixture_file_upload(Rails.root.join('spec/fixtures/capi.png')),
                 fixture_file_upload(Rails.root.join('spec/fixtures/nota-ufjf.pdf')),
@@ -83,8 +83,7 @@ describe 'Curriculum API' do
 
     it 'and tasks are not displayed before the event starts' do
       user = create(:user)
-      event = build(:event, name: 'Ruby on Rails', start_date: Date.tomorrow)
-      schedule_item = build(:schedule_item, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+      schedule_item = build(:schedule_item, name: 'TDD com Rails', description: 'Introdução a programação com TDD', event_start_date: Date.tomorrow)
       curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
       first_content = create(:event_content, user: user, title: 'Ruby para iniciantes', code: 'ABCD1234')
       first_curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: first_content, code: 'XLR8BEN1')
@@ -95,14 +94,14 @@ describe 'Curriculum API' do
       allow(ScheduleItem).to receive(:find).and_return(schedule_item)
       get "/api/v1/curriculums/#{schedule_item.code}"
 
+      json_response = JSON.parse(response.body)
       expect(response).to have_http_status :success
       expect(response.content_type).to include('application/json')
-      curriculum_response = response.parsed_body['curriculum']
-      tasks_response = curriculum_response['curriculum_tasks']
+      tasks_response = json_response['curriculum']['curriculum_tasks']
       expect(tasks_response.length).to eq 2
-      expect(curriculum_response['tasks_available']).to eq false
-      expect(tasks_response[0]).to eq({ title: 'Exercício Rails' })
-      expect(tasks_response[1]).to eq({ title: 'Exercício Stimulus' })
+      expect(json_response['curriculum']['tasks_available']).to eq false
+      expect(tasks_response[0].keys).to eq [ "title" ]
+      expect(tasks_response[1].keys).to eq [ "title" ]
     end
   end
 end

--- a/spec/requests/api/v1/curriculum_api_spec.rb
+++ b/spec/requests/api/v1/curriculum_api_spec.rb
@@ -4,30 +4,22 @@ describe 'Curriculum API' do
   context 'GET /api/v1/curriculums/:schedule_item_code' do
     it 'with success' do
       user = create(:user)
-      build(:event, name: 'Ruby on Rails')
       schedule_item = build(:schedule_item, code: 99, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
       curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
       files = [ fixture_file_upload(Rails.root.join('spec/fixtures/capi.png')),
                 fixture_file_upload(Rails.root.join('spec/fixtures/nota-ufjf.pdf')),
                 fixture_file_upload(Rails.root.join('spec/fixtures/joker.mp4')) ]
-      first_content = user.event_contents.create(title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>', code: 'ABCD1234',
-                                                 external_video_url: 'https://www.youtube.com/watch?v=idaXF2Er4TU', files: files)
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('ABCDEFGH')
-      second_content = user.event_contents.create(title: 'Ruby Video', description: 'Apresentação sobre TDD',
-                                                 external_video_url: 'https://www.youtube.com/watch?v=2DvrRadXwWY')
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('98764512')
-      third_content = user.event_contents.create(title: 'Stimulus', description: 'PDF sobre Stimulus',
-                                                 external_video_url: 'https://www.youtube.com/watch?v=1cw6qO1EYGw')
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('XLR8BE10')
-      first_curriculum_content = create(:curriculum_content, id: 1, curriculum: curriculum, event_content: first_content)
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('CODIGO15')
-      second_curriculum_content = create(:curriculum_content, id: 2, curriculum: curriculum, event_content: second_content)
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('CODIGO26')
-      create(:curriculum_content, curriculum: curriculum, event_content: third_content)
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('CODIGO37')
-      first_task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory)
-      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('CODIGO48')
-      create(:curriculum_task, curriculum: curriculum, title: 'Exercício Stimulus', description: 'Seu primeiro exercício stimulus', certificate_requirement: :optional)
+      first_content = create(:event_content, title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>', code: 'ABCD1234',
+                              external_video_url: 'https://www.youtube.com/watch?v=idaXF2Er4TU', files: files, user: user)
+      second_content = create(:event_content, title: 'Ruby Video', description: 'Apresentação sobre TDD',
+                              external_video_url: 'https://www.youtube.com/watch?v=2DvrRadXwWY', user: user, code: '74851234')
+      third_content = create(:event_content, title: 'Stimulus', description: 'PDF sobre Stimulus',
+                              external_video_url: 'https://www.youtube.com/watch?v=1cw6qO1EYGw', user: user, code: 'WERAG234')
+      first_curriculum_content = create(:curriculum_content, id: 1, curriculum: curriculum, event_content: first_content, code: 'XLR8BE10')
+      second_curriculum_content = create(:curriculum_content, id: 2, curriculum: curriculum, event_content: second_content, code: 'CODIGO15')
+      create(:curriculum_content, curriculum: curriculum, event_content: third_content, code: 'CODIGO26')
+      first_task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory, code: 'CODIGO37')
+      create(:curriculum_task, curriculum: curriculum, title: 'Exercício Stimulus', description: 'Seu primeiro exercício stimulus', certificate_requirement: :optional, code: 'CODIGO48')
       create(:curriculum_task_content, curriculum_task: first_task, curriculum_content: first_curriculum_content)
       create(:curriculum_task_content, curriculum_task: first_task, curriculum_content: second_curriculum_content)
 
@@ -40,14 +32,14 @@ describe 'Curriculum API' do
       tasks_response = curriculum_response['curriculum_tasks']
       contents_response = curriculum_response['curriculum_contents']
       expect(contents_response.length).to eq 3
-      expect(contents_response[0]['code']).to eq first_content.code
+      expect(contents_response[0]['code']).to eq 'ABCD1234'
       expect(contents_response[0]['title']).to eq 'Ruby PDF'
       expect(contents_response[0]['description']).to eq '<strong>Descrição Ruby PDF</strong>'
       expect(contents_response[0]['external_video_url']).to eq "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/idaXF2Er4TU' frameborder='0' allowfullscreen></iframe>"
       expect(contents_response[0]['files'][0]['filename']).to eq 'capi.png'
       expect(contents_response[0]['files'][1]['filename']).to eq 'nota-ufjf.pdf'
       expect(contents_response[0]['files'][2]['filename']).to eq 'joker.mp4'
-      expect(contents_response[1]['code']).to eq 'ABCDEFGH'
+      expect(contents_response[1]['code']).to eq '74851234'
       expect(contents_response[1]['title']).to eq 'Ruby Video'
       expect(contents_response[1]['description']).to eq 'Apresentação sobre TDD'
       expect(contents_response[1]['external_video_url']).to eq "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/2DvrRadXwWY' frameborder='0' allowfullscreen></iframe>"
@@ -59,8 +51,8 @@ describe 'Curriculum API' do
       expect(tasks_response[0]['title']).to eq 'Exercício Rails'
       expect(tasks_response[0]['description']).to eq 'Seu primeiro exercício ruby'
       expect(tasks_response[0]['certificate_requirement']).to eq 'Obrigatória'
-      expect(tasks_response[0]['attached_contents'][0]['attached_content_code']).to eq first_content.code
-      expect(tasks_response[0]['attached_contents'][1]['attached_content_code']).to eq 'ABCDEFGH'
+      expect(tasks_response[0]['attached_contents'][0]['attached_content_code']).to eq 'ABCD1234'
+      expect(tasks_response[0]['attached_contents'][1]['attached_content_code']).to eq '74851234'
       expect(tasks_response[1]['code']).to eq 'CODIGO48'
       expect(tasks_response[1]['title']).to eq 'Exercício Stimulus'
       expect(tasks_response[1]['description']).to eq 'Seu primeiro exercício stimulus'
@@ -77,7 +69,6 @@ describe 'Curriculum API' do
 
     it 'internal server error' do
       user = create(:user)
-      build(:event, name: 'Ruby on Rails')
       schedule_item = build(:schedule_item, code: 99, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
       create(:curriculum, user: user, schedule_item_code: schedule_item.code)
       user.event_contents.create(title: 'Ruby PDF')
@@ -88,6 +79,28 @@ describe 'Curriculum API' do
       expect(response).to have_http_status 500
       expect(response.content_type).to include('application/json')
       expect(response.parsed_body['error']).to eq 'Algo deu errado.'
+    end
+
+    it 'and tasks are not displayed before the event starts' do
+      user = create(:user)
+      event = build(:event, name: 'Ruby on Rails', start_date: Date.tomorrow)
+      schedule_item = build(:schedule_item, name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+      curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
+      first_content = create(:event_content, user: user, title: 'Ruby para iniciantes', code: 'ABCD1234')
+      first_curriculum_content = create(:curriculum_content, curriculum: curriculum, event_content: first_content, code: 'XLR8BEN1')
+      first_task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory)
+      create(:curriculum_task, curriculum: curriculum, title: 'Exercício Stimulus', description: 'Seu primeiro exercício stimulus', certificate_requirement: :optional)
+      create(:curriculum_task_content, curriculum_task: first_task, curriculum_content: first_curriculum_content)
+      create(:curriculum_task_content, curriculum_task: first_task, curriculum_content: second_curriculum_content)
+
+      allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+      get "/api/v1/curriculums/#{schedule_item.code}"
+
+      expect(response).to have_http_status :success
+      expect(response.content_type).to include('application/json')
+      tasks_response = curriculum_response['curriculum_tasks']
+      expect(tasks_response.length).to eq 1
+      expect(tasks_response.last).to eq "As tarefas só serão disponibilizadas após o início do evento (#{event.start_date.strftime('%d/%m/%Y')})"
     end
   end
 end

--- a/spec/requests/api/v1/curriculum_api_spec.rb
+++ b/spec/requests/api/v1/curriculum_api_spec.rb
@@ -11,6 +11,7 @@ describe 'Curriculum API' do
                 fixture_file_upload(Rails.root.join('spec/fixtures/joker.mp4')) ]
       first_content = create(:event_content, title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>',
                               external_video_url: 'https://www.youtube.com/watch?v=idaXF2Er4TU', files: files, user: user)
+      create(:update_history, event_content: first_content, creation_date: Date.today)
       second_content = create(:event_content, title: 'Ruby Video', description: 'Apresentação sobre TDD',
                               external_video_url: 'https://www.youtube.com/watch?v=2DvrRadXwWY', user: user)
       third_content = create(:event_content, title: 'Stimulus', description: 'PDF sobre Stimulus',
@@ -32,7 +33,7 @@ describe 'Curriculum API' do
       tasks_response = curriculum_response['curriculum_tasks']
       contents_response = curriculum_response['curriculum_contents']
       expect(contents_response.length).to eq 3
-      expect(contents_response[0].deep_symbolize_keys).to include({ code: 'XLR8BE10', title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>',
+      expect(contents_response[0].deep_symbolize_keys).to include({ code: 'XLR8BE10', last_update: Date.today.strftime('%d/%m/%Y'), title: 'Ruby PDF', description: '<strong>Descrição Ruby PDF</strong>',
                                                                     external_video_url: "<iframe id='external-video' width='800' height='450' src='https://www.youtube.com/embed/idaXF2Er4TU' frameborder='0' allowfullscreen></iframe>",
                                                                     files: [ { file_download_url: "http://www.example.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--34bb1868318e92534296ce473e5723673680545c/capi.png", filename: 'capi.png' },
                                                                              { file_download_url: "http://www.example.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--c334c3494c13b74df05f58b8166423c4642953bc/nota-ufjf.pdf", filename: 'nota-ufjf.pdf' },

--- a/spec/system/events/user_see_events_spec.rb
+++ b/spec/system/events/user_see_events_spec.rb
@@ -15,7 +15,7 @@ describe 'user visit home and see list of events', type: :system do
   it 'with success' do
     events = []
     2.times do |n|
-      events << build(:event, name: "Event#{ n + 1}")
+      events << build(:event, name: "Event#{ n + 1}", start_date: '2025-02-01')
     end
 
     allow(Event).to receive(:all).and_return(events)


### PR DESCRIPTION
Adiciona informações ao endpoint de currículo e recebe informações sobre o evento dentro do endpoint de schedule_item.

- last_update: Última atualização do conteúdo
- tasks_available: Disponibilidade das tarefas de acordo com a data de início do evento


## Atualizações no endpoint

```
{
  "curriculum": {
    "curriculum_contents": [
      {
        "last_update": "07/02/2025"

        ...

        ]
      }
    ],
    "tasks_available": true

     ...

  }
}
```

Resolve #137 