### PR TITLE
Feat/146 Api para conectar participantes e tarefas

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -111,3 +111,39 @@ Exibe informações relacionadas a um Palestrante, como perfil e foto.
   "error": "Algo deu errado."
 }
 ```
+
+### 3 - Participante finaliza tarefa
+#### POST /api/v1/participant_tasks, params: [:participant_code, :task_code]
+Tabela participant_task é criada, assim como participant_record (caso não exista)
+##### Success
+
+* status: 200
+* content-type: application/json
+
+```
+{
+  "message": "OK"
+}
+```
+
+##### Not Found - quando tarefa não é encontrada
+
+* status: 404
+* content-type: application/json
+
+```
+{
+  "error": "Tarefa não encontrada."
+}
+```
+
+##### Not Found - quando participant_code é vazio
+
+* status: 404
+* content-type: application/json
+
+```
+{
+  "error": "Código do participante não pode ser em branco."
+}
+```

--- a/app/controllers/api/v1/participant_tasks_controller.rb
+++ b/app/controllers/api/v1/participant_tasks_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::ParticipantTasksController < Api::V1::ApiController
+  def create
+    task = CurriculumTask.find_by(code: params[:task_code])
+    return render status: :not_found, json: { error: 'Tarefa não encontrada.' } if task.nil?
+    return render status: :not_found, json: { error: 'Código do participante não pode ser em branco.' } if params[:participant_code].blank?
+
+    participant_record = ParticipantRecord.find_or_create_by(participant_code: params[:participant_code]) do |participant|
+      participant.user_id = task.curriculum.user.id
+      participant.schedule_item_code = task.curriculum.schedule_item_code
+    end
+
+    participant_record.participant_tasks.create(curriculum_task: task, task_status: true)
+    render status: :ok, json: { message: 'OK' }
+  end
+end

--- a/app/models/curriculum_task.rb
+++ b/app/models/curriculum_task.rb
@@ -3,6 +3,7 @@ class CurriculumTask < ApplicationRecord
   enum :certificate_requirement, { mandatory: 1, optional: 0 }, default: :optional
   has_many :curriculum_task_contents
   has_many :curriculum_contents, through: :curriculum_task_contents
+  has_many :participant_tasks
   validates :title, :description, :certificate_requirement, :code, presence: true
   validates :code, uniqueness: true
   validates_uniqueness_of :title, scope: :curriculum_id

--- a/app/models/participant_record.rb
+++ b/app/models/participant_record.rb
@@ -1,3 +1,6 @@
 class ParticipantRecord < ApplicationRecord
   belongs_to :user
+  has_many :participant_tasks
+
+  validates :schedule_item_code, :participant_code, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :curriculums, only: %i[ show ], param: :schedule_item_code
       resources :speakers, only: %i[ show ], param: :email, constraints: { email: /[^\/]+/ }
+      resources :participant_tasks, only: %i[ create ], params: [ :schedule_item_code, :participant_code, :task_code ]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :curriculums, only: %i[ show ], param: :schedule_item_code
       resources :speakers, only: %i[ show ], param: :email, constraints: { email: /[^\/]+/ }
-      resources :participant_tasks, only: %i[ create ], params: [ :schedule_item_code, :participant_code, :task_code ]
+      resources :participant_tasks, only: %i[ create ], params: [ :participant_code, :task_code ]
     end
   end
 end

--- a/db/migrate/20250207141135_add_default_value_to_enabled_certificate_and_task_status.rb
+++ b/db/migrate/20250207141135_add_default_value_to_enabled_certificate_and_task_status.rb
@@ -1,0 +1,6 @@
+class AddDefaultValueToEnabledCertificateAndTaskStatus < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default(:participant_tasks, :task_status, false)
+    change_column_default(:participant_records, :enabled_certificate, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_06_221608) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_07_141135) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -106,7 +106,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_06_221608) do
     t.string "participant_code"
     t.integer "user_id", null: false
     t.string "schedule_item_code"
-    t.boolean "enabled_certificate"
+    t.boolean "enabled_certificate", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_participant_records_on_user_id"
@@ -115,7 +115,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_06_221608) do
   create_table "participant_tasks", force: :cascade do |t|
     t.integer "participant_record_id", null: false
     t.integer "curriculum_task_id", null: false
-    t.boolean "task_status"
+    t.boolean "task_status", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["curriculum_task_id"], name: "index_participant_tasks_on_curriculum_task_id"

--- a/spec/models/participant_record_spec.rb
+++ b/spec/models/participant_record_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ParticipantRecord, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'validations' do
+    it { should belong_to(:user) }
+    it { should have_many(:participant_tasks) }
+    it { should validate_presence_of(:participant_code) }
+    it { should validate_presence_of(:schedule_item_code) }
+  end
 end

--- a/spec/models/participant_task_spec.rb
+++ b/spec/models/participant_task_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ParticipantTask, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'validations' do
+    it { should belong_to(:participant_record) }
+    it { should belong_to(:curriculum_task) }
+  end
 end

--- a/spec/requests/api/v1/participant_task_api_spec.rb
+++ b/spec/requests/api/v1/participant_task_api_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'POST /api/v1/blabla' do
+  it 'with success' do
+    user = create(:user)
+    schedule_item = build(:schedule_item, code: 'ABCD1234', name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
+    task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', code: '1234ABCD',
+                   description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory)
+
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+    post '/api/v1/participant_tasks', params: { participant_code: 'código',  schedule_item_code: 'ABCD1234', task_code: '1234ABCD' }
+
+    expect(response).to have_http_status :success
+    expect(response.content_type).to include('application/json')
+    json_response = JSON.parse(response.body)
+    expect(json_response["participant_record"].deep_symbolyze_keys).to eq({ participant_code: 'código', speaker_id: user.id, schedule_item_code: 'ABCD1234', enebled_certificate: false })
+    expect(json_response["participant_task"].deep_symbolyze_keys).to eq({ participant_record_id: 1,  task_code: '1234ABCD', task_status: false })
+  end
+end

--- a/spec/requests/api/v1/participant_task_api_spec.rb
+++ b/spec/requests/api/v1/participant_task_api_spec.rb
@@ -1,20 +1,60 @@
 require 'rails_helper'
 
-describe 'POST /api/v1/blabla' do
+describe 'POST /api/v1/participant_tasks' do
   it 'with success' do
-    user = create(:user)
+    user = create(:user, id: 10)
     schedule_item = build(:schedule_item, code: 'ABCD1234', name: 'TDD com Rails', description: 'Introdução a programação com TDD')
     curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
     task = create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', code: '1234ABCD',
                    description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory)
 
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
-    post '/api/v1/participant_tasks', params: { participant_code: 'código',  schedule_item_code: 'ABCD1234', task_code: '1234ABCD' }
+    post '/api/v1/participant_tasks', params: { participant_code: 'XLR8BEN1', task_code: '1234ABCD' }
 
     expect(response).to have_http_status :success
     expect(response.content_type).to include('application/json')
     json_response = JSON.parse(response.body)
-    expect(json_response["participant_record"].deep_symbolyze_keys).to eq({ participant_code: 'código', speaker_id: user.id, schedule_item_code: 'ABCD1234', enebled_certificate: false })
-    expect(json_response["participant_task"].deep_symbolyze_keys).to eq({ participant_record_id: 1,  task_code: '1234ABCD', task_status: false })
+    expect(json_response['message']).to eq('OK')
+    expect(ParticipantRecord.count).to eq 1
+    expect(ParticipantRecord.first.attributes.symbolize_keys).to match(a_hash_including(user_id: 10, participant_code: 'XLR8BEN1',
+                                                                                        schedule_item_code: curriculum.schedule_item_code, enabled_certificate: false))
+
+    expect(ParticipantTask.count).to eq 1
+    expect(ParticipantTask.first.attributes.symbolize_keys).to match(a_hash_including(participant_record_id: ParticipantRecord.first.id, curriculum_task_id: task.id,
+                                                                                      task_status: true))
+  end
+
+  it 'not found if task does not exist' do
+    user = create(:user, id: 10)
+    schedule_item = build(:schedule_item, code: 'ABCD1234', name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    create(:curriculum, user: user, schedule_item_code: schedule_item.code)
+
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+    post '/api/v1/participant_tasks', params: { participant_code: 'XLR8BEN1', task_code: 'ERROR_CODE' }
+
+    expect(response).to have_http_status :not_found
+    expect(response.content_type).to include('application/json')
+    json_response = JSON.parse(response.body)
+    expect(json_response['error']).to eq('Tarefa não encontrada.')
+    expect(ParticipantRecord.count).to eq 0
+    expect(ParticipantTask.count).to eq 0
+  end
+
+  it 'not found if participant does not exist' do
+    user = create(:user, id: 10)
+    schedule_item = build(:schedule_item, code: 'ABCD1234', name: 'TDD com Rails', description: 'Introdução a programação com TDD')
+    curriculum = create(:curriculum, user: user, schedule_item_code: schedule_item.code)
+    create(:curriculum_task, curriculum: curriculum, title: 'Exercício Rails', code: '1234ABCD',
+            description: 'Seu primeiro exercício ruby', certificate_requirement: :mandatory)
+
+    allow(ScheduleItem).to receive(:find).and_return(schedule_item)
+    post '/api/v1/participant_tasks', params: { participant_code: '', task_code: '1234ABCD' }
+
+    expect(response).to have_http_status :not_found
+    expect(response.content_type).to include('application/json')
+    json_response = JSON.parse(response.body)
+    expect(json_response['error']).to eq('Código do participante não pode ser em branco.')
+    expect(ParticipantRecord.count).to eq 0
+    expect(ParticipantTask.count).to eq 0
   end
 end


### PR DESCRIPTION
Implementadas o endpoint para criar as tabelas participant_tasks e participant_records, através de uma requisição POST feita na aplicação de participantes

##### Success

```
{
  "message": "OK"
}
```

##### Not Found - quando tarefa não é encontrada

```
{
  "error": "Tarefa não encontrada."
}
```

##### Not Found - quando participant_code é vazio

```
{
  "error": "Código do participante não pode ser em branco."
}
```

Resolve #146 