### PR TITLE
feat/152 Adicionando campo task_status ao endpoint de currículos

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -3,6 +3,7 @@ Documentação da API
 ### 1 - Currículo
 #### GET /api/v1/curriculums/:schedule_item_code
 Exibe as tarefas e conteúdos de um currículo, que representa todos os dados para uma programação.
+Com o campo 'task_status', é possível verificar se a tarefa específica foi concluída por um participante.
 
 * status: 200
 * content-type: application/json
@@ -32,6 +33,7 @@ Exibe as tarefas e conteúdos de um currículo, que representa todos os dados pa
         "title": "Exercício Rails",
         "description": "Seu primeiro exercício ruby",
         "certificate_requirement": "Obrigatória",
+        "task_status": false
         "attached_contents": [
           {
             "attached_content_code": "MH0IBQ8O"

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,10 +3,10 @@ class Api::V1::ApiController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def internal_server_error
-    render status: 500, json: { error: 'Algo deu errado.' }
+    render status: 500, json: { error: I18n.t('internal_server_error') }
   end
 
   def not_found
-    render :not_found, json: { error: 'Recurso não encontrado' }
+    render :not_found, json: { error:  I18n.t('generic_not_found') }
   end
 end

--- a/app/controllers/api/v1/curriculums_controller.rb
+++ b/app/controllers/api/v1/curriculums_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::CurriculumsController < Api::V1::ApiController
   helper ApplicationHelper
   def show
-    @curriculum = Curriculum.find_by(schedule_item_code: params[:schedule_item_code])
+    @curriculum = Curriculum.find_by(schedule_item_code: params[:curriculum_schedule_item_code])
     return render status: :not_found, json: { error: I18n.t('not_found_error', model: Curriculum.model_name.human) } if @curriculum.nil?
 
-    schedule_item = ScheduleItem.find(schedule_item_code: params[:schedule_item_code], token: @curriculum.user.token)
+    participant_record = ParticipantRecord.find_by(participant_code: params[:participant_code], schedule_item_code: params[:curriculum_schedule_item_code])
+    @participant_tasks = participant_record.participant_tasks.map { |task| task.curriculum_task_id } if participant_record
+    schedule_item = ScheduleItem.find(schedule_item_code: params[:curriculum_schedule_item_code], token: @curriculum.user.token)
     @tasks_available = Time.current >= schedule_item.event_start_date
   end
 end

--- a/app/models/participant_record.rb
+++ b/app/models/participant_record.rb
@@ -1,3 +1,6 @@
 class ParticipantRecord < ApplicationRecord
   belongs_to :user
+  has_many :participant_tasks
+
+  validates :schedule_item_code, :participant_code, presence: true
 end

--- a/app/views/api/v1/curriculums/show.json.jbuilder
+++ b/app/views/api/v1/curriculums/show.json.jbuilder
@@ -25,6 +25,11 @@ if @curriculum.present?
           json.title task.title
           json.description task.description
           json.certificate_requirement task.translated_certificate_requirement(task.certificate_requirement)
+          if @participant_tasks.present? && @participant_tasks.include?(task.id)
+            json.task_status true
+          else
+            json.task_status false
+          end
           if task.curriculum_contents.any?
             json.attached_contents task.curriculum_contents do |content|
               json.attached_content_code content.code

--- a/config/locales/apis/v1/pt-BR.yml
+++ b/config/locales/apis/v1/pt-BR.yml
@@ -1,2 +1,4 @@
 pt-BR:
+  generic_not_found: 'Recurso não encontrado!'
   not_found_error: '%{model} não encontrado!'
+  internal_server_error: 'Algo deu errado.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :curriculums, only: %i[ show ], param: :schedule_item_code
+      resources :curriculums, only: %i[], param: :schedule_item_code do
+        resources :participants, only: %i[ show ], param: :participant_code, to: 'curriculums#show'
+      end
       resources :speakers, only: %i[ show ], param: :email, constraints: { email: /[^\/]+/ }
     end
   end


### PR DESCRIPTION
Agora, é possível verificar se um participante (que tem seu código enviado na requisição) já concluiu as tarefas do currículo


```
{
  "curriculum": {
    "curriculum_contents": [
      {
        ...
      }
    ],
    "tasks_available": true
    "curriculum_tasks": [
      {
        "code": "FNRVUEUB",

         ...

        "task_status": false

         ...

        ]
      }
    ]
  }
}
```