### PR TITLE
Fix/161 Bug das redes sociais 

### DIFF
--- a/app/models/social_network.rb
+++ b/app/models/social_network.rb
@@ -3,6 +3,7 @@ class SocialNetwork < ApplicationRecord
   validates :url, :social_network_type, presence: true
   enum :social_network_type, { my_site: 0, youtube: 1, x: 2, github: 3, facebook: 4 }
   validate :validate_url_type
+  validate :valid_protocol
 
   def translated_social_network_type(type)
     I18n.t("activerecord.attributes.social_network.social_network_type.#{type}")
@@ -23,5 +24,9 @@ class SocialNetwork < ApplicationRecord
 
   def valid_my_site_domain?
     /^(https?:\/\/)?([\w\-]+\.)+[a-zA-Z]{2,}(\/[\w\-\.~!*'\(\);:@&=+$,#\[\]]*)?$/.match?(url)
+  end
+
+  def valid_protocol
+    self.url = "https://" + self.url  if self.url.present? && !self.url.start_with?("https://")
   end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,7 +13,7 @@
                 <h3 class="font-bold text-2xl"></h3>
                 <div class="profiles__social_network">
                     <% @profile.social_networks.each do |network| %>
-                            <%= link_to(network.url, class: 'profiles__link', target: "_blank") do %>
+                            <%= link_to(url_for(network.url), class: 'profiles__link', target: "_blank") do %>
                                 <%= raw File.read(Rails.root.join("app", "assets", "images", network.social_network_type + ".svg")) %>
                                 <p><%= network.translated_social_network_type(network.social_network_type) %></p>
                             <% end %>

--- a/spec/models/social_network_spec.rb
+++ b/spec/models/social_network_spec.rb
@@ -6,4 +6,49 @@ RSpec.describe SocialNetwork, type: :model do
     it { should validate_presence_of(:social_network_type) }
     it { should belong_to(:profile) }
   end
+
+  context '.validate_url_type' do
+    it 'with problem for youtube type' do
+      social_network = build(:social_network, social_network_type: 1, url: 'you.com/algumcanal')
+
+      expect(social_network.valid?).to eq(false)
+      expect(social_network.errors.full_messages).to include('Url inválida para Youtube')
+    end
+
+    it 'with problem for x type' do
+      social_network = build(:social_network, social_network_type: 2, url: 'twitterX.com/algumperfil')
+
+      expect(social_network.valid?).to eq(false)
+      expect(social_network.errors.full_messages).to include('Url inválida para X')
+    end
+
+    it 'with problem for GitHub type' do
+      social_network = build(:social_network, social_network_type: 3, url: 'gitlab.com/algumperfil')
+
+      expect(social_network.valid?).to eq(false)
+      expect(social_network.errors.full_messages).to include('Url inválida para GitHub')
+    end
+
+    it 'with problem for Facebook type' do
+      social_network = build(:social_network, social_network_type: 4, url: 'faceapp.com/algumperfil')
+
+      expect(social_network.valid?).to eq(false)
+      expect(social_network.errors.full_messages).to include('Url inválida para Facebook')
+    end
+
+    it 'with problem for a custom site' do
+      social_network = build(:social_network, social_network_type: 0, url: 'algumtexto')
+
+      expect(social_network.valid?).to eq(false)
+      expect(social_network.errors.full_messages).to include('Url inválida para Meu Site')
+    end
+  end
+
+  context 'valid_protocol' do
+    it 'include protocol in url' do
+      social_network = create(:social_network, social_network_type: 1, url: 'www.youtube.com/algumcanal')
+
+      expect(social_network.url).to eq('https://www.youtube.com/algumcanal')
+    end
+  end
 end

--- a/spec/system/events/user_see_event_details_spec.rb
+++ b/spec/system/events/user_see_event_details_spec.rb
@@ -78,7 +78,7 @@ describe 'User see event details', type: :system do
   it 'and event doesnt exists' do
     user = create(:user, first_name: 'User1', last_name: 'LastName1', email: 'user1@email.com', password: '123456')
     create(:profile, user: user)
-    response = instance_double(Faraday::Response, success?: false)
+    instance_double(Faraday::Response, success?: false)
     allow(Event).to receive(:find).and_return(nil)
 
     login_as user, scope: :user


### PR DESCRIPTION
Ao cadastrar uma rede social corretamente mas sem o seu protocolo, o link ao ser clicado redirecionava para uma página relativa
dá aplicação que não existe ao invés de abrir o site de forma externa, com a url completa. Resolve #161 