### PR TITLE
feat/20 Página não autenticada para validação de certificados

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -1,5 +1,14 @@
 class CertificatesController < ApplicationController
+  skip_before_action :set_breadcrumb
   def index; end
+
+  def search
+    @certificate = Certificate.find_by(token: params[:query])
+    return render :index if @certificate
+
+    # flash[:alert] = t('.certificate_not_found') unless @certificate
+    redirect_to certificates_path, alert: t('.index.certificate_not_found')
+  end
 
   def show
     @certificate = Certificate.find_by(token: params[:token])

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -6,7 +6,6 @@ class CertificatesController < ApplicationController
     @certificate = Certificate.find_by(token: params[:query])
     return render :index if @certificate
 
-    # flash[:alert] = t('.certificate_not_found') unless @certificate
     redirect_to certificates_path, alert: t('.index.certificate_not_found')
   end
 

--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -11,7 +11,7 @@
       <%= f.text_field :query, id: 'search_certificate_input' %>
     </div>
     <div class="pb-2">
-      <%= f.submit 'Buscar', class: 'btn_primary' %>
+      <%= f.submit t('.search'), class: 'btn_primary' %>
     </div>
   </div>
 <% end %>

--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -1,0 +1,35 @@
+<div>
+  <h1><%= t('.title') %></h1>
+</div>
+<div class="mt-10">
+  <h3><%= t('.code_input') %></h3>
+</div>
+
+<%= form_with url: search_certificates_path, method: :get do |f| %>
+  <div class="flex items-center gap-3">
+    <div class="field">
+      <%= f.text_field :query, id: 'search_certificate_input' %>
+    </div>
+    <div class="pb-2">
+      <%= f.submit 'Buscar', class: 'btn_primary' %>
+    </div>
+  </div>
+<% end %>
+
+<% if @certificate %>
+  <div class="mt-2 mb-4 text-green-600">
+    <%= t('.valid_certificate', certificate_token: @certificate.token) %>
+  </div>
+  <div class="mt-5 mb-10">
+    <p class="mt-2"><strong><%= t('.student')%>:</strong> <%= @certificate.participant_name %></p>
+    <p class="mt-2"><strong><%= t('.event')%>:</strong> <%= @certificate.event_name %></p>
+    <p class="mt-2"><strong><%= t('.schedule_item')%>:</strong> <%= @certificate.schedule_item_name %></p>
+    <p class="mt-2"><strong><%= t('.instructor')%>:</strong> <%= @certificate.responsable_name %></p>
+    <p class="mt-2"><strong><%= t('.length')%>:</strong> <%= @certificate.length %> <%= t('.minutes') %></p>
+    <p class="mt-2"><strong><%= t('.issue_date')%>:</strong> <%= @certificate.issue_date.strftime('%d/%m/%Y') %></p>
+    <p class="mt-2"><strong><%= t('.certificate_code')%>:</strong> <%= @certificate.token %></p>
+  </div>
+  <div class="mt-5">
+    <%= link_to t('.download_certificate'), certificate_pdf_path(@certificate.token), class: 'btn_primary'%>
+  </div>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -34,8 +34,11 @@
           </div>
         </div>
       <% else %>
-        <%= link_to t('.create_account'), new_user_registration_path, class: 'nav_link_primary' %>
-        <%= link_to t('.access_account'), new_user_session_path, class: 'nav_link_primary' %>
+        <% unless request.path == certificates_path || request.path == search_certificates_path %>
+          <%= link_to t('.validate_certificate'), certificates_path, class: 'nav_link_primary' %>
+        <% end %>
+          <%= link_to t('.create_account'), new_user_registration_path, class: 'nav_link_primary' %>
+          <%= link_to t('.access_account'), new_user_session_path, class: 'nav_link_primary' %>
       <% end %>
     </div>
   </div>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -171,6 +171,7 @@ pt-BR:
       update_description: 'Comentário'
   certificates:
     index:
+      search: 'Buscar'
       certificate_code: 'Código'
       title: 'Valide seu certificado'
       code_input: 'Insira o código único abaixo' 

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -138,6 +138,7 @@ pt-BR:
       lecture: 'Palestra'
       home: 'Início'
       how_work: 'Como Funciona?'
+      validate_certificate: Valide seu certificado 
       create_account: 'Criar conta'
       access_account: 'Acesse sua conta'
       my_contents: 'Meus Conteúdos'
@@ -164,10 +165,26 @@ pt-BR:
       task: 'Tarefa'
       attached_contents: 'Material de apoio'
   update_histories:
-      index:
-        title: 'Histórico de atualizações'
-        update_date: 'Data da atualização'
-        update_description: 'Comentário'
+    index:
+      title: 'Histórico de atualizações'
+      update_date: 'Data da atualização'
+      update_description: 'Comentário'
+  certificates:
+    index:
+      certificate_code: 'Código'
+      title: 'Valide seu certificado'
+      code_input: 'Insira o código único abaixo' 
+      valid_certificate: 'Certificado válido.'
+      certificate_not_found: 'Certificado não encontrado. Caso acredite que seja um erro, entre em contato com o responsável do evento.'
+      student: 'Aluno(a)'
+      event: 'Evento'
+      schedule_item: 'Curso'
+      instructor: 'Instrutor(a)'
+      length: 'Duração'
+      issue_date: 'Data de emissão'
+      minutes: 'minutos'
+      download_certificate: 'Faça o download'
+
   home:
     index:
       register: 'Cadastre-se Agora'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
   root "home#index"
 
   get "certificates/:token.pdf", to: "certificates#show", as: :certificate_pdf
-  resources :certificates, only: %i[ index ]
+  resources :certificates, only: %i[ index ] do
+    get 'search', on: :collection
+  end
   resources :events, only: %i[ index show ], param: :code
   resources :event_contents, only: %i[ index show new create edit update ], param: :code do
     resources :update_histories, only: %i[ index ]

--- a/spec/requests/certificates/participant_sees_your_certificate_spec.rb
+++ b/spec/requests/certificates/participant_sees_your_certificate_spec.rb
@@ -8,7 +8,6 @@ describe 'Participante sees your certificate' do
     event = build(:event, name: 'Ruby on Rails', start_date: 7.days.ago, end_date: 1.day.ago)
     schedule_item = build(:schedule_item, name: 'Palestra sobre TDD', start_time: Time.now,
                           end_time: Time.now + 1.hour, date: 2.days.ago)
-    user = create(:user, first_name: 'Maria', last_name: 'Josefina')
 
     certificate = create(:certificate,
       user: user,

--- a/spec/system/certificate/user_validates_certificate_spec.rb
+++ b/spec/system/certificate/user_validates_certificate_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe 'User validates certificate', type: :system do
+  it 'with success' do
+    user = create(:user, first_name: 'Otávio', last_name: 'Campus')
+    participant = build(:participant, name: 'Erika', last_name: 'Campus', cpf: '548.966.630-71')
+    event = build(:event, name: 'Ruby on Rails')
+    schedule_item = build(:schedule_item, name: 'Palestra sobre TDD')
+    certificate = create(:certificate,
+      user: user,
+      responsable_name: user.full_name,
+      schedule_item_name: schedule_item.name,
+      event_name: event.name,
+      issue_date: Date.current,
+      length: '60 minutos',
+      token: 'H897E6JPN1KTR6BY4VOP',
+      participant_name: Participant.full_name(participant.name, participant.last_name)
+    )
+
+    visit certificates_path
+
+    fill_in 'search_certificate_input', with: 'H897E6JPN1KTR6BY4VOP'
+    click_on 'Buscar'
+
+    expect(current_path).to eq search_certificates_path
+    expect(page).to have_content 'Certificado válido.'
+    expect(page).to have_content "Aluno(a): Erika Campus"
+    expect(page).to have_content "Evento: Ruby on Rails"
+    expect(page).to have_content "Curso: Palestra sobre TDD"
+    expect(page).to have_content "Instrutor(a): Otávio Campus"
+    expect(page).to have_content "Duração: 60 minutos"
+    expect(page).to have_content "Data de emissão: #{certificate.issue_date.strftime('%d/%m/%Y')}"
+    expect(page).to have_content "Código: H897E6JPN1KTR6BY4VOP"
+    expect(page).to have_link "Faça o download"
+  end
+
+  it 'and certificate token is invalid' do
+    create(:certificate, token: 'H897E6JPN1KTR6BY4VOP')
+
+    visit certificates_path
+
+    fill_in 'search_certificate_input', with: 'INVALIDCODE'
+    click_on 'Buscar'
+
+    expect(current_path).to eq certificates_path
+    expect(page).to have_content 'Certificado não encontrado. Caso acredite que seja um erro, entre em contato com o responsável do evento.'
+  end
+end


### PR DESCRIPTION
## Funcionalidades
- Um visitante não autenticado pode acessar a rota `certificates_path` para validar um certificado através de seu código único;
- Foi criada a rota search_certificates_path para buscar no banco de dados se o código inserido faz parte de algum certificado.
- Caso o código seja válido, serão exibidas algumas das informações presentes no certificado;
- Implementado um link de 'Faça o download', que leva o usuário para o show do certificado.

## Navegação

Novo link na landing page:

![image](https://github.com/user-attachments/assets/9877f180-ee60-4aa1-841d-c56df08b5a4f)

Página para validação:

![image](https://github.com/user-attachments/assets/3c57e1dc-8ae1-4899-b7e7-fd044e9b05dc)

Ao inserir um código válido:

![image](https://github.com/user-attachments/assets/c2a9c78d-6bb3-435f-8839-238b7fc6b45b)

Ao inserir um código inválido:

![image](https://github.com/user-attachments/assets/fa07f4dc-b504-4155-8fc6-6fbbb587d91b)

Resolve #20
