### PR TITLE
feat/179 Adiciona certificate_url ao endpoint de currículo

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -27,8 +27,8 @@ Se disponível, a url para visualização do certificado será exibida em 'certi
         ]
       }
     ],
-    "tasks_available": true
-    "certificate_url": ""http://localhost:3000/certificates/PIMZBVXM04DWVNVWI90H.pdf""
+    "tasks_available": true,
+    "certificate_url": ""http://localhost:3000/certificates/PIMZBVXM04DWVNVWI90H.pdf"",
     "curriculum_tasks": [
       {
         "code": "FNRVUEUB",

--- a/APIDOC.md
+++ b/APIDOC.md
@@ -4,6 +4,7 @@ Documentação da API
 #### GET /api/v1/curriculums/:schedule_item_code
 Exibe as tarefas e conteúdos de um currículo, que representa todos os dados para uma programação.
 Com o campo 'task_status', é possível verificar se a tarefa específica foi concluída por um participante.
+Se disponível, a url para visualização do certificado será exibida em 'certificate_url'
 
 * status: 200
 * content-type: application/json
@@ -27,6 +28,7 @@ Com o campo 'task_status', é possível verificar se a tarefa específica foi co
       }
     ],
     "tasks_available": true
+    "certificate_url": ""http://localhost:3000/certificates/PIMZBVXM04DWVNVWI90H.pdf""
     "curriculum_tasks": [
       {
         "code": "FNRVUEUB",
@@ -55,6 +57,7 @@ Com o campo 'task_status', é possível verificar se a tarefa específica foi co
 ```
 
 * curriculum_contents: Conteúdos;
+  - last_update: Última atualização do conteúdo;
   - code: Código de identificação;
   - title: Título;
   - description: Descrição com texto enriquecido;
@@ -62,6 +65,8 @@ Com o campo 'task_status', é possível verificar se a tarefa específica foi co
 * files: Arquivos;
   - filename: Nome do arquivo;
   - file_download_url: URL do arquivo;
+* task_available: Diz se as tarefas do currículo já estão disponíveis;
+* certificate_url: Disponibiliza a url para visualização do certificado;
 * curriculum_tasks: Tarefas;
   - code: Código de identificação;
   - title: Título;

--- a/app/controllers/api/v1/curriculums_controller.rb
+++ b/app/controllers/api/v1/curriculums_controller.rb
@@ -8,5 +8,7 @@ class Api::V1::CurriculumsController < Api::V1::ApiController
     @participant_tasks = participant_record.participant_tasks.map { |task| task.curriculum_task_id } if participant_record
     schedule_item = ScheduleItem.find(schedule_item_code: params[:curriculum_schedule_item_code], token: @curriculum.user.token)
     @tasks_available = Time.current >= schedule_item.event_start_date
+
+    @certificate = Certificate.find_by(participant_code: params[:participant_code], schedule_item_code: params[:curriculum_schedule_item_code]) if participant_record && participant_record.enabled_certificate
   end
 end

--- a/app/views/api/v1/curriculums/show.json.jbuilder
+++ b/app/views/api/v1/curriculums/show.json.jbuilder
@@ -18,6 +18,7 @@ if @curriculum.present?
       end
     end
     json.tasks_available @tasks_available
+    json.certificate_url certificate_pdf_url(@certificate.token) if @certificate.present?
     if  @curriculum.curriculum_tasks.any?
       json.curriculum_tasks @curriculum.curriculum_tasks do |task|
         if @tasks_available

--- a/spec/requests/api/v1/participant_certificate_spec.rb
+++ b/spec/requests/api/v1/participant_certificate_spec.rb
@@ -48,7 +48,7 @@ describe 'Participant requests certificate', type: :request do
     allow(ScheduleItem).to receive(:find).and_return(schedule_item)
     allow(Event).to receive(:find).and_return(event)
     allow(Participant).to receive(:find).and_return(participant)
-    participant_record = create(:participant_record, user: user, participant_code: 'ABC123', schedule_item_code: schedule_item.code, enabled_certificate: true)
+    create(:participant_record, user: user, participant_code: 'ABC123', schedule_item_code: schedule_item.code, enabled_certificate: true)
 
     get api_v1_curriculum_certificate_path(curriculum_schedule_item_code: schedule_item.code, participant_code: 'Something')
 
@@ -81,7 +81,6 @@ describe 'Participant requests certificate', type: :request do
     get api_v1_curriculum_certificate_path(curriculum_schedule_item_code: 'Something', participant_code: 'Something')
 
     expect(response.content_type).to include 'application/json'
-    json_response = JSON.parse(response.body)
     expect(response).to have_http_status :internal_server_error
     expect(response.parsed_body['error']).to eq 'Algo deu errado.'
   end


### PR DESCRIPTION
Se disponível, a URL para visualizar o certificado do participante será exibida no endpoint de currículo.

```
{
  "curriculum": {
    "curriculum_contents": [
       ...
    ],

    "tasks_available": true,
    "certificate_url": ""http://localhost:3000/certificates/PIMZBVXM04DWVNVWI90H.pdf"",

    "curriculum_tasks": [
       ...
    ]
  }
}
```